### PR TITLE
Utility class to inspect binary files and internal registration

### DIFF
--- a/src/test/java/cn/nukkit/BlockStateReader.java
+++ b/src/test/java/cn/nukkit/BlockStateReader.java
@@ -1,0 +1,41 @@
+package cn.nukkit;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteOrder;
+
+import com.google.common.primitives.Ints;
+
+import cn.nukkit.nbt.NBTIO;
+import cn.nukkit.nbt.tag.CompoundTag;
+import cn.nukkit.nbt.tag.ListTag;
+import cn.nukkit.nbt.tag.Tag;
+
+public class BlockStateReader {
+    public static void main(String[] args) {
+        ListTag<CompoundTag> tags;
+        try (InputStream stream = Server.class.getClassLoader().getResourceAsStream("runtime_block_states.dat")) {
+            if (stream == null) {
+                throw new AssertionError("Unable to locate block state nbt");
+            }
+            
+            //noinspection unchecked
+            tags = (ListTag<CompoundTag>) NBTIO.readTag(stream, ByteOrder.LITTLE_ENDIAN, false);
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+
+        for (CompoundTag state : tags.getAll()) {
+            CompoundTag block = state.getCompound("block");
+            if (block.getString("name").toLowerCase().contains("piston")) {
+                StringBuilder builder = new StringBuilder(block.getString("name"));
+                for (Tag tag : block.getCompound("states").getAllTags()) {
+                    builder.append(';').append(tag.getName()).append('=').append(tag.parseValue());
+                }
+                System.out.println(builder.toString());
+                System.out.println(Ints.asList(state.getIntArray("meta")));
+                System.out.println();
+            }
+        }
+    }
+}


### PR DESCRIPTION
I'll be adding to this branch utility classes which can be used to inspect data from files like `runtime_block_states.dat`, so we know if the block that we are changing is fully registered or not.

`BlockStateReader` has a `main` class which can be executed normally, it will print to the console the block name, the block properties and the int meta which represents that state in Nukkit.

The name block which is being inspected should be replaced in:
```java
if (block.getString("name").toLowerCase().contains("piston")) {
```

`[]` means that there are no int id associated to that state, so Nukkit basically ignores it or replace with an other block or state

`[8, 14, 15]` means that `8` is the main state and `14`, and `15` are illegal states which ends up showing the same thing as `8`

`[9]` meas that the state is mapped to the meta `9` and it has no other state falling back to it.

You can copy this class to the `test` folder to inspect the files, Nukkit doesn't needs to be running. Just take care to do not commit this file. Move it to an other changelist so it won't show up in the commit dialog.