### PR TITLE
Fixes firework being overridden with a black creeper face

### DIFF
--- a/src/main/java/cn/nukkit/dispenser/FireworksDispenseBehavior.java
+++ b/src/main/java/cn/nukkit/dispenser/FireworksDispenseBehavior.java
@@ -6,15 +6,19 @@ import cn.nukkit.entity.item.EntityFirework;
 import cn.nukkit.item.Item;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.Vector3;
+import cn.nukkit.nbt.NBTIO;
+import cn.nukkit.nbt.tag.CompoundTag;
 
 public class FireworksDispenseBehavior extends DefaultDispenseBehavior {
 
     @Override
     public Item dispense(BlockDispenser block, BlockFace face, Item item) {
-        Vector3 pos = block.getSide(face).add(0, 0.2);
+        BlockFace opposite = face.getOpposite();
+        Vector3 pos = block.getSide(face).add(0.5 + opposite.getXOffset()*0.2, 0.5 + opposite.getYOffset()*0.2, 0.5 + opposite.getZOffset()*0.2);
 
-        EntityFirework firework = new EntityFirework(block.level.getChunk(pos.getChunkX(), pos.getChunkZ()),
-                Entity.getDefaultNBT(pos));
+        CompoundTag nbt = Entity.getDefaultNBT(pos);
+        nbt.putCompound("FireworkItem", NBTIO.putItemHelper(item));
+        EntityFirework firework = new EntityFirework(block.level.getChunk(pos.getChunkX(), pos.getChunkZ()), nbt);
         firework.spawnToAll();
 
         return null;

--- a/src/main/java/cn/nukkit/entity/data/EntityMetadata.java
+++ b/src/main/java/cn/nukkit/entity/data/EntityMetadata.java
@@ -1,5 +1,6 @@
 package cn.nukkit.entity.data;
 
+import cn.nukkit.api.PowerNukkitDifference;
 import cn.nukkit.item.Item;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.math.Vector3f;
@@ -20,15 +21,14 @@ public class EntityMetadata {
         return this.getOrDefault(id, null);
     }
 
+    @PowerNukkitDifference(info = "Reduce a lot of hidden NullPointerExceptions", since = "1.3.1.2-PN")
     public EntityData getOrDefault(int id, EntityData defaultValue) {
-        try {
-            return this.map.getOrDefault(id, defaultValue).setId(id);
-        } catch (Exception e) {
-            if (defaultValue != null) {
-                return defaultValue.setId(id);
-            }
+        EntityData data = this.map.getOrDefault(id, defaultValue);
+        if (data == null) {
             return null;
         }
+        data.setId(id);
+        return data;
     }
 
     public boolean exists(int id) {

--- a/src/main/java/cn/nukkit/entity/item/EntityFirework.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityFirework.java
@@ -1,6 +1,7 @@
 package cn.nukkit.entity.item;
 
 import cn.nukkit.Server;
+import cn.nukkit.api.PowerNukkitDifference;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.entity.data.ByteEntityData;
 import cn.nukkit.entity.data.IntEntityData;
@@ -12,8 +13,10 @@ import cn.nukkit.item.ItemFirework;
 import cn.nukkit.level.format.FullChunk;
 import cn.nukkit.nbt.NBTIO;
 import cn.nukkit.nbt.tag.CompoundTag;
+import cn.nukkit.nbt.tag.ListTag;
 import cn.nukkit.network.protocol.EntityEventPacket;
 import cn.nukkit.network.protocol.LevelSoundEventPacket;
+import cn.nukkit.utils.DyeColor;
 
 import java.util.Random;
 
@@ -28,6 +31,7 @@ public class EntityFirework extends Entity {
     private int lifetime;
     private Item firework;
 
+    @PowerNukkitDifference(info = "Will default to a black-creeper-face if the firework data is missing", since = "1.3.1.2-PN")
     public EntityFirework(FullChunk chunk, CompoundTag nbt) {
         super(chunk, nbt);
 
@@ -43,6 +47,27 @@ public class EntityFirework extends Entity {
             firework = NBTIO.getItemHelper(nbt.getCompound("FireworkItem"));
         } else {
             firework = new ItemFirework();
+        }
+
+        if (!firework.hasCompoundTag() || !firework.getNamedTag().contains("Fireworks")) {
+            CompoundTag tag = firework.getNamedTag();
+            if (tag == null) {
+                tag = new CompoundTag();
+            }
+
+            CompoundTag ex = new CompoundTag()
+                    .putByteArray("FireworkColor", new byte[]{(byte) DyeColor.BLACK.getDyeData()})
+                    .putByteArray("FireworkFade", new byte[]{})
+                    .putBoolean("FireworkFlicker", false)
+                    .putBoolean("FireworkTrail", false)
+                    .putByte("FireworkType", ItemFirework.FireworkExplosion.ExplosionType.CREEPER_SHAPED.ordinal());
+
+            tag.putCompound("Fireworks", new CompoundTag("Fireworks")
+                    .putList(new ListTag<CompoundTag>("Explosions").add(ex))
+                    .putByte("Flight", 1)
+            );
+
+            firework.setNamedTag(tag);
         }
 
         this.setDataProperty(new NBTEntityData(Entity.DATA_DISPLAY_ITEM, firework.getNamedTag()));

--- a/src/main/java/cn/nukkit/item/ItemFirework.java
+++ b/src/main/java/cn/nukkit/item/ItemFirework.java
@@ -1,6 +1,7 @@
 package cn.nukkit.item;
 
 import cn.nukkit.Player;
+import cn.nukkit.api.PowerNukkitDifference;
 import cn.nukkit.block.Block;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.entity.item.EntityFirework;
@@ -29,30 +30,10 @@ public class ItemFirework extends Item {
     public ItemFirework(Integer meta) {
         this(meta, 1);
     }
-
+    
+    @PowerNukkitDifference(info = "Will not add compound tag automatically")
     public ItemFirework(Integer meta, int count) {
         super(FIREWORKS, meta, count, "Fireworks");
-
-        if (!hasCompoundTag() || !this.getNamedTag().contains("Fireworks")) {
-            CompoundTag tag = getNamedTag();
-            if (tag == null) {
-                tag = new CompoundTag();
-
-                CompoundTag ex = new CompoundTag()
-                        .putByteArray("FireworkColor", new byte[]{(byte) DyeColor.BLACK.getDyeData()})
-                        .putByteArray("FireworkFade", new byte[]{})
-                        .putBoolean("FireworkFlicker", false)
-                        .putBoolean("FireworkTrail", false)
-                        .putByte("FireworkType", FireworkExplosion.ExplosionType.CREEPER_SHAPED.ordinal());
-
-                tag.putCompound("Fireworks", new CompoundTag("Fireworks")
-                        .putList(new ListTag<CompoundTag>("Explosions").add(ex))
-                        .putByte("Flight", 1)
-                );
-
-                this.setNamedTag(tag);
-            }
-        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #397

* [x] Default fireworks does not have a default NBT tag anymore
* [x] When an entity firework is created without a firework data, it defaults to the old black creeper that was being used by default in the item's NBT tags.
* [x] Fixed firework spawn position when fired by dispensers
* [x] Fixed dispensers always dispensing black creeper fireworks
* [x] Fixed grabbing fireworks from creative and firing it would fire a black creeper firework.