### PR TITLE
Fix error sending chunk when it has invalid block states

### DIFF
--- a/src/main/java/cn/nukkit/blockstate/BigIntegerMutableBlockState.java
+++ b/src/main/java/cn/nukkit/blockstate/BigIntegerMutableBlockState.java
@@ -7,6 +7,7 @@ import cn.nukkit.block.Block;
 import cn.nukkit.blockproperty.BlockProperties;
 import cn.nukkit.blockproperty.BlockProperty;
 import cn.nukkit.blockproperty.exception.InvalidBlockPropertyException;
+import cn.nukkit.blockproperty.exception.InvalidBlockPropertyMetaException;
 import cn.nukkit.blockstate.exception.InvalidBlockStateException;
 import cn.nukkit.math.NukkitMath;
 import lombok.EqualsAndHashCode;
@@ -18,6 +19,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.NoSuchElementException;
 
 import static cn.nukkit.blockstate.IMutableBlockState.handleUnsupportedStorageType;
 
@@ -148,6 +150,10 @@ public class BigIntegerMutableBlockState extends MutableBlockState {
         return properties.getBooleanValue(storage, propertyName);
     }
 
+    /**
+     * @throws NoSuchElementException If the property is not registered
+     * @throws InvalidBlockPropertyMetaException If the meta contains invalid data
+     */
     @Nonnull
     @Override
     public String getPersistenceValue(String propertyName) {

--- a/src/main/java/cn/nukkit/blockstate/BlockState.java
+++ b/src/main/java/cn/nukkit/blockstate/BlockState.java
@@ -254,10 +254,6 @@ public final class BlockState implements Serializable, IBlockState {
         return storage.getHugeDamage();
     }
 
-    /**
-     * @throws NoSuchElementException If the property is not registered
-     * @throws InvalidBlockPropertyValueException If the new value is not accepted by the property
-     */
     @Nonnull
     @Override
     public Object getPropertyValue(String propertyName) {

--- a/src/main/java/cn/nukkit/blockstate/BlockStateRegistry.java
+++ b/src/main/java/cn/nukkit/blockstate/BlockStateRegistry.java
@@ -2,6 +2,8 @@ package cn.nukkit.blockstate;
 
 import cn.nukkit.Server;
 import cn.nukkit.api.DeprecationDetails;
+import cn.nukkit.api.PowerNukkitOnly;
+import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockID;
 import cn.nukkit.block.BlockUnknown;
@@ -429,6 +431,18 @@ public class BlockStateRegistry {
             }
         }
         return null;
+    }
+    
+    @PowerNukkitOnly
+    @Since("1.4.0.0-PN")
+    public int getFallbackRuntimeId() {
+        return updateBlockRegistration.runtimeId;
+    }
+
+    @PowerNukkitOnly
+    @Since("1.4.0.0-PN")
+    public BlockState getFallbackBlockState() {
+        return updateBlockRegistration.state;
     }
     
     @AllArgsConstructor

--- a/src/main/java/cn/nukkit/blockstate/Loggers.java
+++ b/src/main/java/cn/nukkit/blockstate/Loggers.java
@@ -1,0 +1,17 @@
+package cn.nukkit.blockstate;
+
+import cn.nukkit.api.PowerNukkitOnly;
+import cn.nukkit.api.Since;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * @author joserobjr
+ */
+@PowerNukkitOnly("Only for internal use")
+@Since("1.4.0.0-PN")
+final class Loggers {
+    private Loggers(){ throw new UnsupportedOperationException(); }
+    
+    static final Logger logIBlockState = LogManager.getLogger(IBlockState.class);
+}

--- a/src/test/java/cn/nukkit/level/format/anvil/util/BlockStorageTest.java
+++ b/src/test/java/cn/nukkit/level/format/anvil/util/BlockStorageTest.java
@@ -1,8 +1,11 @@
 package cn.nukkit.level.format.anvil.util;
 
+import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockID;
 import cn.nukkit.block.BlockStone;
 import cn.nukkit.blockstate.BlockState;
+import cn.nukkit.utils.BinaryStream;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +32,12 @@ class BlockStorageTest {
     int x;
     int y;
     int z;
-    
+
+    @BeforeAll
+    static void beforeAll() {
+        Block.init();
+    }
+
     @BeforeEach
     void setUp() {
         blockStorage = new BlockStorage();
@@ -368,5 +376,14 @@ class BlockStorageTest {
         assertEquals(STATUS_DENY, blockStorage.getBlockChangeStateAbove(x, y+3, z));
         assertEquals(STATUS_ALLOW, blockStorage.getBlockChangeStateAbove(x, y+4, z));
         assertEquals(STATUS_ALLOW, blockStorage.getBlockChangeStateAbove(x, y+5, z));
+    }
+
+    @Test
+    void writeToWithInvalidData() {
+        assertFalse(blockStorage.isPaletteUpdateDelayed());
+        blockStorage.setBlockState(x, y, z, BlockState.of(BlockID.POLISHED_BLACKSTONE_BRICK_WALL, 7));
+        assertTrue(blockStorage.isPaletteUpdateDelayed());
+        BinaryStream stream = new BinaryStream();
+        blockStorage.writeTo(stream);
     }
 }


### PR DESCRIPTION
Fixes:
```java
2020-09-03 08:48:57.917 [main] FATAL - An error has occurred while trying to get the stateId of state: 533:7 - BlockProperties{bitSize=9, properties=[0-2:wall_connection_type_south, 2-4:wall_connection_type_west, 4-6:wall_connection_type_north, 6-8:wall_connection_type_east, 8-9:wall_post_bit]} - minecraft:polished_blackstone_brick_wall
cn.nukkit.blockproperty.exception.InvalidBlockPropertyMetaException: Property: wall_connection_type_south. Current Meta: 7, Invalid Meta: 3
    at cn.nukkit.blockproperty.BlockProperty.getPersistenceValue(BlockProperty.java:322) ~[powernukkit.jar:?]
    at cn.nukkit.blockproperty.BlockProperties.getPersistenceValue(BlockProperties.java:458) ~[powernukkit.jar:?]
    at cn.nukkit.blockstate.BlockState$IntStorage.getPersistenceValue(BlockState.java:492) ~[powernukkit.jar:?]
    at cn.nukkit.blockstate.BlockState.getPersistenceValue(BlockState.java:280) ~[powernukkit.jar:?]
    at cn.nukkit.blockstate.IBlockState.lambda$getStateId$0(IBlockState.java:102) ~[powernukkit.jar:?]
at java.util.LinkedHashMap$LinkedKeySet.forEach(LinkedHashMap.java:559) ~[?:1.8.0_265]
    at java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1082) ~[?:1.8.0_265]
    at cn.nukkit.blockstate.IBlockState.getStateId(IBlockState.java:102) ~[powernukkit.jar:?]
    at cn.nukkit.blockstate.BlockStateRegistry.findRegistrationByStateId(BlockStateRegistry.java:258) ~[powernukkit.jar:?]
    at cn.nukkit.blockstate.BlockStateRegistry.findRegistration(BlockStateRegistry.java:249) ~[powernukkit.jar:?]
    at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1688) [?:1.8.0_265]
    at cn.nukkit.blockstate.BlockStateRegistry.getRegistration(BlockStateRegistry.java:223) [powernukkit.jar:?]
    at cn.nukkit.blockstate.BlockStateRegistry.getRuntimeId(BlockStateRegistry.java:219) [powernukkit.jar:?]
    at cn.nukkit.blockstate.IBlockState.getRuntimeId(IBlockState.java:282) [powernukkit.jar:?]
    at cn.nukkit.level.format.anvil.util.BlockStorage.writeTo(BlockStorage.java:442) [powernukkit.jar:?]
    at cn.nukkit.level.format.anvil.ChunkSection.writeTo(ChunkSection.java:561) [powernukkit.jar:?]
    at cn.nukkit.level.format.anvil.Anvil.requestChunkTask(Anvil.java:157) [powernukkit.jar:?]
    at cn.nukkit.level.Level.processChunkRequest(Level.java:2996) [powernukkit.jar:?]
    at cn.nukkit.level.Level.doTick(Level.java:940) [powernukkit.jar:?]
    at cn.nukkit.Server.checkTickUpdates(Server.java:1266) [powernukkit.jar:?]
    at cn.nukkit.Server.tick(Server.java:1348) [powernukkit.jar:?]
    at cn.nukkit.Server.tickProcessor(Server.java:1120) [powernukkit.jar:?]
    at cn.nukkit.Server.start(Server.java:1088) [powernukkit.jar:?]
    at cn.nukkit.Server.<init>(Server.java:744) [powernukkit.jar:?]
    at cn.nukkit.Nukkit.main(Nukkit.java:120) [powernukkit.jar:?]
Caused by: java.lang.IndexOutOfBoundsException: index (3) must be less than size (3)
    at com.google.common.base.Preconditions.checkElementIndex(Preconditions.java:1348) ~[powernukkit.jar:?]
    at com.google.common.base.Preconditions.checkElementIndex(Preconditions.java:1330) ~[powernukkit.jar:?]
    at cn.nukkit.blockproperty.ArrayBlockProperty.validateMetaDirectly(ArrayBlockProperty.java:176) ~[powernukkit.jar:?]
    at cn.nukkit.blockproperty.ArrayBlockProperty.getPersistenceValueForMeta(ArrayBlockProperty.java:154) ~[powernukkit.jar:?]
    at cn.nukkit.blockproperty.BlockProperty.getPersistenceValue(BlockProperty.java:320) ~[powernukkit.jar:?]
    ... 24 more
```

https://discordapp.com/channels/728280425255927879/728284682646716416/750865598212472884