### PR TITLE
Fix grass spread/decay, light props of ice variants; upgrade dirt, podzol, grass, grass_path

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockDirt.java
+++ b/src/main/java/cn/nukkit/block/BlockDirt.java
@@ -1,6 +1,12 @@
 package cn.nukkit.block;
 
 import cn.nukkit.Player;
+import cn.nukkit.api.PowerNukkitOnly;
+import cn.nukkit.api.Since;
+import cn.nukkit.blockproperty.ArrayBlockProperty;
+import cn.nukkit.blockproperty.BlockProperties;
+import cn.nukkit.blockproperty.BlockProperty;
+import cn.nukkit.blockproperty.value.DirtType;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
 import cn.nukkit.item.ItemTool;
@@ -8,12 +14,21 @@ import cn.nukkit.level.Sound;
 import cn.nukkit.utils.BlockColor;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Optional;
 
 /**
  * @author MagicDroidX (Nukkit Project), kvetinac97
  */
 
 public class BlockDirt extends BlockSolidMeta {
+    @PowerNukkitOnly
+    @Since("1.4.0.0-PN")
+    public static final BlockProperty<DirtType> DIRT_TYPE = new ArrayBlockProperty<>("dirt_type", true, DirtType.class);
+
+    @PowerNukkitOnly
+    @Since("1.4.0.0-PN")
+    public static final BlockProperties PROPERTIES = new BlockProperties(DIRT_TYPE);
 
     public BlockDirt() {
         this(0);
@@ -28,11 +43,32 @@ public class BlockDirt extends BlockSolidMeta {
         return DIRT;
     }
 
+    @Since("1.4.0.0-PN")
+    @PowerNukkitOnly
+    @Nonnull
+    @Override
+    public BlockProperties getProperties() {
+        return PROPERTIES;
+    }
+    
+    @PowerNukkitOnly
+    @Since("1.4.0.0-PN")
+    @Nonnull
+    public Optional<DirtType> getDirtType() {
+        return Optional.of(getPropertyValue(DIRT_TYPE));
+    }
+
+    @PowerNukkitOnly
+    @Since("1.4.0.0-PN")
+    public void setDirtType(@Nullable DirtType dirtType) {
+        setPropertyValue(DIRT_TYPE, dirtType);
+    }
+    
     @Override
     public boolean canBeActivated() {
         return true;
     }
-
+    
     @Override
     public double getResistance() {
         return 2.5;

--- a/src/main/java/cn/nukkit/block/BlockGrass.java
+++ b/src/main/java/cn/nukkit/block/BlockGrass.java
@@ -2,10 +2,14 @@ package cn.nukkit.block;
 
 import cn.nukkit.Player;
 import cn.nukkit.Server;
+import cn.nukkit.api.PowerNukkitDifference;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockproperty.BlockProperties;
 import cn.nukkit.blockproperty.CommonBlockProperties;
+import cn.nukkit.blockproperty.exception.InvalidBlockPropertyValueException;
+import cn.nukkit.blockproperty.value.DirtType;
+import cn.nukkit.event.block.BlockFadeEvent;
 import cn.nukkit.event.block.BlockSpreadEvent;
 import cn.nukkit.item.Item;
 import cn.nukkit.level.Level;
@@ -17,6 +21,9 @@ import cn.nukkit.math.Vector3;
 import cn.nukkit.utils.BlockColor;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * @author Angelic47 (Nukkit Project)
@@ -61,6 +68,23 @@ public class BlockGrass extends BlockDirt {
         return "Grass Block";
     }
 
+    @Since("1.4.0.0-PN")
+    @PowerNukkitOnly
+    @Nonnull
+    @Override
+    public Optional<DirtType> getDirtType() {
+        return Optional.empty();
+    }
+
+    @Since("1.4.0.0-PN")
+    @PowerNukkitOnly
+    @Override
+    public void setDirtType(@Nullable DirtType dirtType) {
+        if (dirtType != null) {
+            throw new InvalidBlockPropertyValueException(DIRT_TYPE, null, dirtType, getName()+" don't support DirtType");
+        }
+    }
+
     @Override
     public boolean onActivate(@Nonnull Item item) {
         return this.onActivate(item, null);
@@ -94,33 +118,56 @@ public class BlockGrass extends BlockDirt {
         return false;
     }
 
+    @PowerNukkitDifference(since = "1.4.0.0-PN", info = "Fixed grass spread and decay logic to match vanilla behaviour")
     @Override
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_RANDOM) {
+            // Grass dies and changes to dirt after a random time (when a random tick lands on the block) 
+            // if directly covered by any opaque block.
+            // Transparent blocks can kill grass in a similar manner, 
+            // but only if they cause the light level above the grass block to be four or below (like water does), 
+            // and the surrounding area is not otherwise sufficiently lit up.
+            if (up().getLightFilter() > 1) {
+                BlockFadeEvent ev = new BlockFadeEvent(this, Block.get(BlockID.DIRT));
+                Server.getInstance().getPluginManager().callEvent(ev);
+                if (!ev.isCancelled()) {
+                    this.getLevel().setBlock(this, ev.getNewState());
+                    return type;
+                }
+            }
+            
+            // Grass can spread to nearby dirt blocks. 
+            // Grass spreading without player intervention depends heavily on the time of day. 
+            // For a dirt block to accept grass from a nearby grass block, the following requirements must be met:
+            
+            // The source block must have a light level of 9 or brighter directly above it.
             if (getLevel().getFullLight(add(0, 1, 0)) >= BlockCrops.MINIMUM_LIGHT_LEVEL) {
-                NukkitRandom random = new NukkitRandom();
-                x = random.nextRange((int) x - 1, (int) x + 1);
-                y = random.nextRange((int) y - 2, (int) y + 2);
-                z = random.nextRange((int) z - 1, (int) z + 1);
+                
+                // The dirt block receiving grass must be within a 3×5×3 range of the source block 
+                // where the source block is in the center of the second topmost layer of that range.
+                ThreadLocalRandom random = ThreadLocalRandom.current();
+                int x = random.nextInt((int) this.x - 1, (int) this.x + 1 + 1);
+                int y = random.nextInt((int) this.y - 3, (int) this.y + 1 + 1);
+                int z = random.nextInt((int) this.z - 1, (int) this.z + 1 + 1);
                 Block block = this.getLevel().getBlock(new Vector3(x, y, z));
-                if (block.getId() == Block.DIRT && block.getDamage() == 0) {
-                    if (block.up() instanceof BlockAir) {
-                        BlockSpreadEvent ev = new BlockSpreadEvent(block, this, Block.get(BlockID.GRASS));
-                        Server.getInstance().getPluginManager().callEvent(ev);
-                        if (!ev.isCancelled()) {
-                            this.getLevel().setBlock(block, ev.getNewState());
-                        }
-                    }
-                } else if (block.getId() == Block.GRASS) {
-                    if (block.up() instanceof BlockSolid) {
-                        BlockSpreadEvent ev = new BlockSpreadEvent(block, this, Block.get(BlockID.DIRT));
-                        Server.getInstance().getPluginManager().callEvent(ev);
-                        if (!ev.isCancelled()) {
-                            this.getLevel().setBlock(block, ev.getNewState());
-                        }
+                if (block.getId() == Block.DIRT
+                        
+                        // It cannot spread to coarse dirt        
+                        && block.getPropertyValue(DIRT_TYPE) == DirtType.NORMAL
+                        
+                        // The dirt block must have a light level of at least 4 above it.
+                        && getLevel().getFullLight(block) >= 4
+                        
+                        // Any block directly above the dirt block must not reduce light by 2 levels or more.
+                        && block.up().getLightFilter() < 2) {
+                    BlockSpreadEvent ev = new BlockSpreadEvent(block, this, Block.get(BlockID.GRASS));
+                    Server.getInstance().getPluginManager().callEvent(ev);
+                    if (!ev.isCancelled()) {
+                        this.getLevel().setBlock(block, ev.getNewState());
                     }
                 }
             }
+            return type;
         }
         return 0;
     }

--- a/src/main/java/cn/nukkit/block/BlockIcePacked.java
+++ b/src/main/java/cn/nukkit/block/BlockIcePacked.java
@@ -1,5 +1,8 @@
 package cn.nukkit.block;
 
+import cn.nukkit.api.PowerNukkitDifference;
+import cn.nukkit.api.PowerNukkitOnly;
+import cn.nukkit.api.Since;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemTool;
 
@@ -45,5 +48,18 @@ public class BlockIcePacked extends BlockIce {
     @Override
     public boolean canSilkTouch() {
         return true;
+    }
+
+    @PowerNukkitDifference(since = "1.4.0.0-PN", info = "Returns false ")
+    @Override
+    public boolean isTransparent() {
+        return false;
+    }
+
+    @Since("1.4.0.0-PN")
+    @PowerNukkitOnly
+    @Override
+    public int getLightFilter() {
+        return 15;
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockPodzol.java
+++ b/src/main/java/cn/nukkit/block/BlockPodzol.java
@@ -5,10 +5,14 @@ import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockproperty.BlockProperties;
 import cn.nukkit.blockproperty.CommonBlockProperties;
+import cn.nukkit.blockproperty.exception.InvalidBlockPropertyValueException;
+import cn.nukkit.blockproperty.value.DirtType;
 import cn.nukkit.item.Item;
 import cn.nukkit.utils.BlockColor;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Optional;
 
 /**
  * @author xtypr
@@ -41,6 +45,23 @@ public class BlockPodzol extends BlockDirt {
     @Override
     public String getName() {
         return "Podzol";
+    }
+
+    @Since("1.4.0.0-PN")
+    @PowerNukkitOnly
+    @Nonnull
+    @Override
+    public Optional<DirtType> getDirtType() {
+        return Optional.empty();
+    }
+
+    @Since("1.4.0.0-PN")
+    @PowerNukkitOnly
+    @Override
+    public void setDirtType(@Nullable DirtType dirtType) {
+        if (dirtType != null) {
+            throw new InvalidBlockPropertyValueException(DIRT_TYPE, null, dirtType, getName()+" don't support DirtType");
+        }
     }
 
     @Override

--- a/src/main/java/cn/nukkit/blockproperty/value/DirtType.java
+++ b/src/main/java/cn/nukkit/blockproperty/value/DirtType.java
@@ -1,0 +1,19 @@
+package cn.nukkit.blockproperty.value;
+
+import cn.nukkit.api.PowerNukkitOnly;
+import cn.nukkit.api.Since;
+
+/**
+ * @author joserobjr
+ */
+@PowerNukkitOnly
+@Since("1.4.0.0-PN")
+public enum DirtType {
+    @PowerNukkitOnly
+    @Since("1.4.0.0-PN")
+    NORMAL,
+
+    @PowerNukkitOnly
+    @Since("1.4.0.0-PN")
+    COARSE
+}

--- a/src/test/java/cn/nukkit/ServerTest.java
+++ b/src/test/java/cn/nukkit/ServerTest.java
@@ -8,7 +8,7 @@ import java.lang.reflect.Field;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-class ServerTest {
+public class ServerTest {
     public static void setInstance(Server server) {
         assertDoesNotThrow(()-> {
                     Field instance = Server.class.getDeclaredField("instance");

--- a/src/test/java/cn/nukkit/block/BlockGrassTest.java
+++ b/src/test/java/cn/nukkit/block/BlockGrassTest.java
@@ -1,0 +1,133 @@
+package cn.nukkit.block;
+
+import cn.nukkit.Server;
+import cn.nukkit.ServerTest;
+import cn.nukkit.blockstate.BlockState;
+import cn.nukkit.event.block.BlockSpreadEvent;
+import cn.nukkit.item.Item;
+import cn.nukkit.level.Level;
+import cn.nukkit.math.Vector3;
+import cn.nukkit.plugin.PluginManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author joserobjr
+ */
+@ExtendWith(MockitoExtension.class)
+class BlockGrassTest {
+    static final BlockState STATE_DIRT = BlockState.of(BlockID.DIRT);
+    static final BlockState STATE_GRASS = BlockState.of(BlockID.GRASS);
+    
+    int x = 1, y = 2, z = 3;
+    
+    @Mock
+    PluginManager pluginManager;
+    
+    @Mock
+    Server server;
+    
+    @Mock
+    Level level;
+    
+    BlockGrass grass;
+
+    @Test
+    void spread() {
+        Map<Vector3, BlockState> states = Collections.synchronizedMap(new LinkedHashMap<>());
+        when(level.getFullLight(any())).thenReturn(15);
+        when(level.getBlock(any())).then(call-> {
+            Vector3 pos = call.getArgument(0);
+            return states.getOrDefault(pos, BlockState.AIR)
+                    .getBlock((Level) call.getMock(), pos.getFloorX(), pos.getFloorY(), pos.getFloorZ());
+        });
+        when(level.getBlock(anyInt(), anyInt(), anyInt(), anyInt())).then(call-> {
+            int x = call.getArgument(0);
+            int y = call.getArgument(1);
+            int z = call.getArgument(2);
+            int layer = call.getArgument(3);
+            if (layer != 0) return BlockState.AIR.getBlock(level, x, y, z, layer);
+            return states.getOrDefault(new Vector3(x, y, z), BlockState.AIR).getBlock(level, x, y, z, layer);
+        });
+        when(level.setBlock(any(), any())).then(call-> {
+            Vector3 pos = call.getArgument(0);
+            Block block = call.getArgument(1);
+            states.put(new Vector3(pos.x, pos.y, pos.z), block.getCurrentState());
+            return null;
+        });
+
+        for (int y1 = y - 15; y1 <= y + 15; y1 += 2) {
+            for (int x1 = x - 15; x1 <= x + 15; x1++) {
+                for (int z1 = z - 15; z1 <= z + 15; z1++) {
+                    states.put(new Vector3(x1, y1, z1), STATE_DIRT);
+                }
+            }
+        }
+        
+        states.put(new Vector3(x, y+1, z), BlockState.AIR);
+        states.put(new Vector3(x, y, z), STATE_GRASS);
+        
+        Map<Vector3, BlockState> expected = new LinkedHashMap<>(states);
+        for (int y1 = y - 3; y1 <= y + 1; y1 += 2) {
+            for (int x1 = x - 1; x1 <= x + 1; x1++) {
+                for (int z1 = z - 1; z1 <= z + 1; z1++) {
+                    expected.put(new Vector3(x1, y1, z1), STATE_GRASS);
+                }
+            }
+        }
+
+        expected.put(new Vector3(x, y + 1, z), BlockState.AIR);
+        expected.put(new Vector3(x, y - 1, z), STATE_DIRT);
+
+        for (int i = 0; i < 1_000; i++) {
+            grass.onUpdate(Level.BLOCK_UPDATE_RANDOM);
+        }
+        
+        verify(level, times(0)).setBlock(eq(new Vector3(x, y, z)), any());
+        verify(pluginManager, times(9 * 3 - 2)).callEvent(isA(BlockSpreadEvent.class));
+        assertEquals(expected, states);
+    }
+    
+    @Test
+    void decay() {
+        when(level.getBlock(anyInt(), anyInt(), anyInt(), anyInt())).then(call-> {
+            int x = call.getArgument(0);
+            int y = call.getArgument(1);
+            int z = call.getArgument(2);
+            int layer = call.getArgument(3);
+            return STATE_DIRT.getBlock(level, x, y, z, layer);
+        });
+        
+        grass.onUpdate(Level.BLOCK_UPDATE_RANDOM);
+        verify(level).setBlock(eq(new Vector3(x,y,z)), eq(Block.get(BlockID.DIRT)));
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        Block.init();
+        Item.init();
+    }
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(server.getPluginManager()).thenReturn(pluginManager);
+        ServerTest.setInstance(server);
+        grass = (BlockGrass) Block.get(BlockID.GRASS);
+        grass.level = level;
+        grass.x = x;
+        grass.y = y;
+        grass.z = z;
+    }
+}

--- a/src/test/java/cn/nukkit/math/NukkitRandomTest.java
+++ b/src/test/java/cn/nukkit/math/NukkitRandomTest.java
@@ -1,0 +1,36 @@
+package cn.nukkit.math;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author joserobjr
+ */
+class NukkitRandomTest {
+    NukkitRandom random;
+    
+    @Test
+    void nextRange() {
+        Boolean[] matched = new Boolean[8-2 + 1];
+        Arrays.fill(matched, Boolean.FALSE);
+        for (int i = 0; i < 1000; i++) {
+            int rand = random.nextRange(2, 8);
+            assertThat(rand).isIn(2, 3, 4, 5, 6, 7, 8);
+            matched[rand-2] = Boolean.TRUE;
+        }
+        Boolean[] expected = new Boolean[matched.length];
+        Arrays.fill(expected, Boolean.TRUE);
+        assertEquals(Arrays.asList(expected), Arrays.asList(matched));
+    }
+
+    @BeforeEach
+    void setUp() {
+        random = new NukkitRandom(ThreadLocalRandom.current().nextLong()); 
+    }
+}

--- a/src/test/java/cn/nukkit/test/answer/AnswerPositionedBlock.java
+++ b/src/test/java/cn/nukkit/test/answer/AnswerPositionedBlock.java
@@ -1,0 +1,27 @@
+package cn.nukkit.test.answer;
+
+import cn.nukkit.block.Block;
+import cn.nukkit.blockstate.BlockState;
+import cn.nukkit.level.Level;
+import lombok.RequiredArgsConstructor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+/**
+ * @author joserobjr
+ */
+@RequiredArgsConstructor
+public class AnswerPositionedBlock implements Answer<Block> {
+    private final BlockState state;
+    
+    @Override
+    public Block answer(InvocationOnMock invocationOnMock) {
+        Level level = (Level) invocationOnMock.getMock();
+        Object[] arguments = invocationOnMock.getArguments();
+        int x = (Integer) arguments[0];
+        int y = (Integer) arguments[1];
+        int z = (Integer) arguments[2];
+        int layer = (Integer) arguments[3];
+        return state.getBlock(level, x, y, z, layer);
+    }
+}

--- a/src/test/java/cn/nukkit/test/matcher/ExtraArgumentMatchers.java
+++ b/src/test/java/cn/nukkit/test/matcher/ExtraArgumentMatchers.java
@@ -1,0 +1,53 @@
+package cn.nukkit.test.matcher;
+
+import org.mockito.ArgumentMatcher;
+import org.mockito.internal.progress.ThreadSafeMockingProgress;
+
+/**
+ * @author joserobjr
+ */
+public class ExtraArgumentMatchers {
+    public static byte inRange(byte fromInclusive, byte toInclusive) {
+        reportMatcher(new InRange<>(fromInclusive, toInclusive));
+        return 0;
+    }
+    
+    public static short inRange(short fromInclusive, short toInclusive) {
+        reportMatcher(new InRange<>(fromInclusive, toInclusive));
+        return 0;
+    }
+    
+    public static char inRange(char fromInclusive, char toInclusive) {
+        reportMatcher(new InRange<>(fromInclusive, toInclusive));
+        return 0;
+    }
+    
+    public static int inRange(int fromInclusive, int toInclusive) {
+        reportMatcher(new InRange<>(fromInclusive, toInclusive));
+        return 0;
+    }
+    
+    public static long inRange(long fromInclusive, long toInclusive) {
+        reportMatcher(new InRange<>(fromInclusive, toInclusive));
+        return 0;
+    }
+    
+    public static float inRange(float fromInclusive, float toInclusive) {
+        reportMatcher(new InRange<>(fromInclusive, toInclusive));
+        return 0;
+    }
+    
+    public static double inRange(double fromInclusive, double toInclusive) {
+        reportMatcher(new InRange<>(fromInclusive, toInclusive));
+        return 0;
+    }
+    
+    public static <C extends Comparable<C>> C inRange(C fromInclusive, C toInclusive) {
+        reportMatcher(new InRange<>(fromInclusive, toInclusive));
+        return fromInclusive;
+    }
+
+    private static void reportMatcher(ArgumentMatcher<?> matcher) {
+        ThreadSafeMockingProgress.mockingProgress().getArgumentMatcherStorage().reportMatcher(matcher);
+    }
+}

--- a/src/test/java/cn/nukkit/test/matcher/InRange.java
+++ b/src/test/java/cn/nukkit/test/matcher/InRange.java
@@ -1,0 +1,20 @@
+package cn.nukkit.test.matcher;
+
+import lombok.RequiredArgsConstructor;
+import org.mockito.ArgumentMatcher;
+
+import java.io.Serializable;
+
+/**
+ * @author joserobjr
+ */
+@RequiredArgsConstructor
+public class InRange<C extends Comparable<C>> implements ArgumentMatcher<C>, Serializable {
+    private final C from;
+    private final C to;
+    
+    @Override
+    public boolean matches(C comparable) {
+        return from.compareTo(comparable) <= 0 && to.compareTo(comparable) >= 1;
+    }
+}


### PR DESCRIPTION
Fix #382 

Also, when grass is decaying to dirt, it will call `BlockFadeEvent` instead of `BlockFadeEvent`