### PR TITLE
Fixes a duplication bug with 5 blocks GUI

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -267,6 +267,9 @@ public class Server {
         if (tempDir.isFile() && !tempDir.delete()) {
             throw new IOException("Failed to delete " + tempDir);
         }
+        instance = this;
+        CraftingManager.packet = new BatchPacket();
+        CraftingManager.packet.payload = new byte[0];
         
         currentThread = Thread.currentThread();
         File abs = tempDir.getAbsoluteFile();
@@ -290,10 +293,12 @@ public class Server {
         banByIP = new BanList(dataPath + "banned-ips.json");
         operators = new Config();
         whitelist = new Config();
+        commandMap = new SimpleCommandMap(this);
         
         setMaxPlayers(10);
-        
-        instance = this;
+
+        this.registerEntities();
+        this.registerBlockEntities();
     }
 
     Server(final String filePath, String dataPath, String pluginPath, String predefinedLanguage) {

--- a/src/main/java/cn/nukkit/inventory/DoubleChestInventory.java
+++ b/src/main/java/cn/nukkit/inventory/DoubleChestInventory.java
@@ -68,8 +68,8 @@ public class DoubleChestInventory extends ContainerInventory implements Inventor
     }
 
     @Override
-    public boolean clear(int index) {
-        return index < this.left.getSize() ? this.left.clear(index) : this.right.clear(index - this.right.getSize());
+    public boolean clear(int index, boolean send) {
+        return index < this.left.getSize() ? this.left.clear(index, send) : this.right.clear(index - this.right.getSize(), send);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/inventory/PlayerUIComponent.java
+++ b/src/main/java/cn/nukkit/inventory/PlayerUIComponent.java
@@ -51,6 +51,11 @@ public class PlayerUIComponent extends BaseInventory {
     }
 
     @Override
+    public boolean clear(int index, boolean send) {
+        return this.playerUI.clear(index + this.offset, send);
+    }
+
+    @Override
     public Map<Integer, Item> getContents() {
         Map<Integer, Item> contents = playerUI.getContents();
         contents.keySet().removeIf(slot -> slot < offset || slot > offset + size);

--- a/src/test/java/cn/nukkit/PlayerTest.java
+++ b/src/test/java/cn/nukkit/PlayerTest.java
@@ -6,10 +6,7 @@ import cn.nukkit.dispenser.DispenseBehaviorRegister;
 import cn.nukkit.entity.Attribute;
 import cn.nukkit.entity.data.Skin;
 import cn.nukkit.event.entity.EntityDamageEvent;
-import cn.nukkit.inventory.EnchantInventory;
-import cn.nukkit.inventory.Inventory;
 import cn.nukkit.inventory.PlayerInventory;
-import cn.nukkit.inventory.transaction.data.UseItemData;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemID;
 import cn.nukkit.item.enchantment.Enchantment;
@@ -19,7 +16,6 @@ import cn.nukkit.level.Position;
 import cn.nukkit.level.biome.EnumBiome;
 import cn.nukkit.level.format.anvil.Anvil;
 import cn.nukkit.level.format.anvil.Chunk;
-import cn.nukkit.math.BlockFace;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.network.Network;
 import cn.nukkit.network.SourceInterface;
@@ -54,7 +50,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
@@ -111,35 +106,6 @@ class PlayerTest {
     Skin skin;
     
     Player player;
-    
-    @Test
-    void enchantingTableDupe() {
-        level.setBlock(player, Block.get(BlockID.ENCHANTING_TABLE));
-        doReturn(-1).when(server).getSpawnRadius();
-
-        UseItemData useItemData = new UseItemData();
-        useItemData.itemInHand = player.getInventory().getItemInHand().clone();
-        useItemData.clickPos = player.asVector3f();
-        useItemData.blockPos = player.asBlockVector3();
-        useItemData.face = BlockFace.UP;
-        useItemData.actionType = InventoryTransactionPacket.USE_ITEM_ACTION_CLICK_BLOCK;
-        
-        InventoryTransactionPacket packet = new InventoryTransactionPacket();
-        packet.transactionType = InventoryTransactionPacket.TYPE_USE_ITEM;
-        packet.transactionData = useItemData;
-        packet.actions = new NetworkInventoryAction[0];
-        player.handleDataPacket(packet);
-
-        Inventory inventory = player.getTopWindow().orElse(null);
-        assertThat(inventory).isInstanceOf(EnchantInventory.class);
-        EnchantInventory enchantInventory = (EnchantInventory) inventory;
-        assert enchantInventory != null;
-        
-        inventory = player.getInventory();
-        
-        enchantInventory.setItem(0, Item.get(ItemID.IRON_SWORD), false);
-        
-    }
     
     @Test
     void armorDamage() {

--- a/src/test/java/cn/nukkit/inventory/EnchantInventoryTest.java
+++ b/src/test/java/cn/nukkit/inventory/EnchantInventoryTest.java
@@ -1,0 +1,85 @@
+package cn.nukkit.inventory;
+
+import cn.nukkit.Player;
+import cn.nukkit.Server;
+import cn.nukkit.ServerTest;
+import cn.nukkit.block.Block;
+import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemID;
+import cn.nukkit.level.Level;
+import cn.nukkit.level.Position;
+import cn.nukkit.plugin.PluginManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author joserobjr
+ */
+@ExtendWith(MockitoExtension.class)
+class EnchantInventoryTest {
+    @Mock
+    PluginManager pluginManager;
+    
+    @Mock
+    Server server;
+    
+    @Mock
+    Level level;
+
+    @Mock
+    Player player;
+    
+    PlayerInventory playerInventory;
+
+    PlayerUIInventory playerUIInventory;
+
+    EnchantInventory enchantInventory;
+
+    @Test
+    void close() {
+        doCallRealMethod().when(player).resetCraftingGridType();
+        enchantInventory.setItem(0, Item.get(ItemID.IRON_SWORD));
+        enchantInventory.close(player);
+        int count = 0;
+        for (int i = 0; i < playerInventory.getSize(); i++) {
+            if (playerInventory.getItem(i).getId() == ItemID.IRON_SWORD) {
+                count++;
+            }
+        }
+        for (int i = 0; i < playerUIInventory.getSize(); i++) {
+            if (playerUIInventory.getItem(i).getId() == ItemID.IRON_SWORD) {
+                count++;
+            }
+        }
+        assertEquals(1, count, "The sword was duplicated!");
+    }
+
+    @BeforeEach
+    void setUp() {
+        playerInventory = spy(new PlayerInventory(player));
+        playerUIInventory = spy(new PlayerUIInventory(player));
+        
+        lenient().when(player.getInventory()).thenReturn(playerInventory);
+        lenient().when(player.getUIInventory()).thenReturn(playerUIInventory);
+        lenient().when(player.getLevel()).thenReturn(level);
+        lenient().when(player.getServer()).thenReturn(server);
+        lenient().when(level.getServer()).thenReturn(server);
+        lenient().when(server.getPluginManager()).thenReturn(pluginManager);
+        ServerTest.setInstance(server);
+        
+        enchantInventory = new EnchantInventory(playerUIInventory, new Position(1, 2, 3, level));
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        Block.init();
+        Item.init();
+    }
+}


### PR DESCRIPTION
Affected blocks:
- Enchanting Table
- Anvil
- Grindstone
- Stonecutter
- Beacon

There were also risks involving:
- Crafting table
- 2x2 Crafting Grid
- Double chests