### PR TITLE
Random fixes for 1.4.0.0-PN-SNAPSHOT

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -1883,11 +1883,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             this.dummyBossBars.values().forEach(DummyBossBar::updateBossEntityPosition);
         }
 
-        this.setDataFlag(DATA_FLAGS_EXTENDED, DATA_FLAG_BLOCKING,
-                getNoShieldTicks() == 0
-                && (this.isSneaking() || getRiding() != null) 
-                && (this.getInventory().getItemInHand().getId() == ItemID.SHIELD || this.getOffhandInventory().getItem(0).getId() == ItemID.SHIELD));
-
         updateBlockingFlag();
         return true;
     }
@@ -5422,14 +5417,12 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     }
 
     private void updateBlockingFlag() {
-        boolean shieldInHand = this.getInventory().getItemInHand().getId() == ItemID.SHIELD;
-        boolean shieldInOffhand = this.getOffhandInventory().getItem(0).getId() == ItemID.SHIELD;
-        if (isBlocking()) {
-            if (!isSneaking() || (!shieldInHand && !shieldInOffhand)) {
-                this.setBlocking(false);
-            }
-        } else if (isSneaking() && (shieldInHand || shieldInOffhand)) {
-            this.setBlocking(true);
+        boolean shouldBlock = getNoShieldTicks() == 0
+                && (this.isSneaking() || getRiding() != null)
+                && (this.getInventory().getItemInHand().getId() == ItemID.SHIELD || this.getOffhandInventory().getItem(0).getId() == ItemID.SHIELD);
+        
+        if (isBlocking() != shouldBlock) {
+            this.setBlocking(shouldBlock);
         }
     }
 

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -884,6 +884,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         this.sendPotionEffects(this);
         this.sendData(this);
         this.inventory.sendContents(this);
+        this.inventory.sendHeldItem(this);
         this.inventory.sendArmorContents(this);
         this.offhandInventory.sendContents(this);
 
@@ -891,11 +892,13 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         setTimePacket.time = this.level.getTime();
         this.dataPacket(setTimePacket);
 
-        Position pos;
+        Location pos;
         if(this.server.isSafeSpawn()) {
-            pos = this.level.getSafeSpawn(this);
+            pos = this.level.getSafeSpawn(this).getLocation();
+            pos.yaw = this.yaw;
+            pos.pitch = this.pitch;
         } else {
-            pos = new Position(this.forceMovement.x,this.forceMovement.y,this.forceMovement.z,this.level);
+            pos = new Location(this.forceMovement.x,this.forceMovement.y,this.forceMovement.z, this.yaw, this.pitch, this.level);
         }
 
 
@@ -903,7 +906,18 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
         this.server.getPluginManager().callEvent(respawnEvent);
 
-        pos = respawnEvent.getRespawnPosition();
+        Position fromEvent = respawnEvent.getRespawnPosition();
+        if (fromEvent instanceof Location) {
+            pos = fromEvent.getLocation();
+        } else {
+            pos = fromEvent.getLocation();
+            pos.yaw = this.yaw;
+            pos.pitch = this.pitch;
+        }
+
+        this.teleport(pos, null);
+        lastYaw = yaw;
+        lastPitch = pitch;
 
         this.sendPlayStatus(PlayStatusPacket.PLAYER_SPAWN);
 
@@ -944,8 +958,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         if (level != 0) {
             this.sendExperienceLevel(this.getExperienceLevel());
         }
-
-        this.teleport(pos, null); // Prevent PlayerTeleportEvent during player spawn
 
         if (!this.isSpectator()) {
             this.spawnToAll();
@@ -4650,7 +4662,9 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
             this.teleportPosition = new Vector3(this.x, this.y, this.z);
             this.forceMovement = this.teleportPosition;
-            this.sendPosition(this, this.yaw, this.pitch, MovePlayerPacket.MODE_TELEPORT);
+            this.yaw = to.yaw;
+            this.pitch = to.pitch;
+            this.sendPosition(this, to.yaw, to.pitch, MovePlayerPacket.MODE_TELEPORT);
 
             this.checkTeleportPosition();
 

--- a/src/main/java/cn/nukkit/api/PowerNukkitDifference.java
+++ b/src/main/java/cn/nukkit/api/PowerNukkitDifference.java
@@ -14,7 +14,7 @@ import java.lang.annotation.*;
 @Since("1.3.0.0-PN")
 @Inherited
 @Documented
-@Repeatable(PowerNukkitDifference.List.class)
+@Repeatable(PowerNukkitDifference.DifferenceList.class)
 public @interface PowerNukkitDifference {
     String info();
     String since() default "";
@@ -26,7 +26,7 @@ public @interface PowerNukkitDifference {
     @Since("1.4.0.0-PN")
     @Inherited
     @Documented
-    @interface List {
+    @interface DifferenceList {
         PowerNukkitDifference[] value();
     }
 }

--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -2059,4 +2059,10 @@ public abstract class Block extends Position implements Metadatable, Cloneable, 
     public boolean isDefaultState() {
         return mutableState == null || mutableState.isDefaultState();
     }
+
+    @PowerNukkitOnly
+    @Since("1.4.0.0-PN")
+    public int getItemMaxStackSize() {
+        return 64;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockLantern.java
+++ b/src/main/java/cn/nukkit/block/BlockLantern.java
@@ -108,7 +108,7 @@ public class BlockLantern extends BlockFlowable {
                     level.useBreakOn(this, ItemTool.getBestTool(getToolType()));
                 }
             } else if (!isBlockAboveValid()) {
-                level.useBreakOn(this);
+                level.useBreakOn(this, ItemTool.getBestTool(getToolType()));
             }
             return type;
         }

--- a/src/main/java/cn/nukkit/block/BlockMoving.java
+++ b/src/main/java/cn/nukkit/block/BlockMoving.java
@@ -51,7 +51,7 @@ public class BlockMoving extends BlockTransparent implements BlockEntityHolder<B
 
     @Override
     public boolean place(@Nonnull Item item, @Nonnull Block block, @Nonnull Block target, @Nonnull BlockFace face, double fx, double fy, double fz, @Nullable Player player) {
-        return BlockEntityHolder.setBlockAndCreateEntity(this) != null;
+        return false;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockUndyedShulkerBox.java
+++ b/src/main/java/cn/nukkit/block/BlockUndyedShulkerBox.java
@@ -213,4 +213,11 @@ public class BlockUndyedShulkerBox extends BlockTransparent implements BlockEnti
     public boolean isSolid(BlockFace side) {
         return false;
     }
+
+    @Since("1.4.0.0-PN")
+    @PowerNukkitOnly
+    @Override
+    public int getItemMaxStackSize() {
+        return 1;
+    }
 }

--- a/src/main/java/cn/nukkit/blockentity/BlockEntity.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntity.java
@@ -111,7 +111,11 @@ public abstract class BlockEntity extends Position {
         }
 
         this.initBlockEntity();
-
+        
+        if (closed) {
+            throw new IllegalStateException("Could not create the entity "+getClass().getName()+", the initializer closed it on construction.");
+        }
+        
         this.chunk.addBlockEntity(this);
         this.getLevel().addBlockEntity(this);
     }

--- a/src/main/java/cn/nukkit/command/defaults/GiveCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/GiveCommand.java
@@ -1,11 +1,13 @@
 package cn.nukkit.command.defaults;
 
 import cn.nukkit.Player;
+import cn.nukkit.block.BlockUnknown;
 import cn.nukkit.command.Command;
 import cn.nukkit.command.CommandSender;
 import cn.nukkit.command.data.CommandParamType;
 import cn.nukkit.command.data.CommandParameter;
 import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemBlock;
 import cn.nukkit.lang.TranslationContainer;
 import cn.nukkit.utils.TextFormat;
 
@@ -61,6 +63,11 @@ public class GiveCommand extends VanillaCommand {
             item = Item.fromString(args[1]);
         } catch (Exception e) {
             sender.sendMessage(new TranslationContainer("commands.generic.usage", this.usageMessage));
+            return true;
+        }
+        
+        if (item instanceof ItemBlock && item.getBlock() instanceof BlockUnknown) {
+            sender.sendMessage(new TranslationContainer("commands.give.block.notFound", args[1]));
             return true;
         }
 

--- a/src/main/java/cn/nukkit/command/defaults/GiveCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/GiveCommand.java
@@ -9,6 +9,9 @@ import cn.nukkit.item.Item;
 import cn.nukkit.lang.TranslationContainer;
 import cn.nukkit.utils.TextFormat;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author xtypr
  * @since 2015/12/9
@@ -51,7 +54,7 @@ public class GiveCommand extends VanillaCommand {
             return true;
         }
 
-        Player player = sender.getServer().getPlayer(args[0]);
+        Player player = sender instanceof Player && "@p".equals(args[0])? (Player) sender : sender.getServer().getPlayer(args[0]);
         Item item;
 
         try {
@@ -61,23 +64,56 @@ public class GiveCommand extends VanillaCommand {
             return true;
         }
 
+        int count;
         try {
-            item.setCount(Integer.parseInt(args[2]));
-        } catch (Exception e) {
-            item.setCount(item.getMaxStackSize());
-        }
-
-        if (player != null) {
-            if (item.getId() == 0) {
-                sender.sendMessage(new TranslationContainer(TextFormat.RED + "%commands.give.item.notFound", args[1]));
-                return true;
+            if (args.length <= 2) {
+                count = 1;
+            } else {
+                count = Integer.parseInt(args[2]);
             }
-            player.getInventory().addItem(item.clone());
-        } else {
-            sender.sendMessage(new TranslationContainer(TextFormat.RED + "%commands.generic.player.notFound"));
-
+        } catch (NumberFormatException e) {
+            count = 1;
+        }
+        if (count <= 0) {
+            sender.sendMessage(new TranslationContainer("commands.generic.usage", this.usageMessage));
             return true;
         }
+        item.setCount(count);
+
+        if (player == null) {
+            sender.sendMessage(new TranslationContainer(TextFormat.RED + "%commands.generic.player.notFound"));
+            return true;
+        }
+        
+        if (item.isNull()) {
+            sender.sendMessage(new TranslationContainer(TextFormat.RED + "%commands.give.item.notFound", args[1]));
+            return true;
+        }
+        
+        Item[] returns = player.getInventory().addItem(item.clone());
+        List<Item> drops = new ArrayList<>();
+        for (Item returned: returns) {
+            int maxStackSize = returned.getMaxStackSize();
+            if (returned.getCount() <= maxStackSize) {
+                drops.add(returned);
+            } else {
+                while (returned.getCount() > maxStackSize) {
+                    Item drop = returned.clone();
+                    int toDrop = Math.min(returned.getCount(), maxStackSize);
+                    drop.setCount(toDrop);
+                    returned.setCount(returned.getCount() - toDrop);
+                    drops.add(drop);
+                }
+                if (!returned.isNull()) {
+                    drops.add(returned);
+                }
+            }
+        }
+        
+        for (Item drop: drops) {
+            player.dropItem(drop);
+        }
+        
         Command.broadcastCommandMessage(sender, new TranslationContainer(
                 "%commands.give.success",
                 item.getName() + " (" + item.getId() + ":" + item.getDamage() + ")",

--- a/src/main/java/cn/nukkit/entity/EntityHumanType.java
+++ b/src/main/java/cn/nukkit/entity/EntityHumanType.java
@@ -51,6 +51,9 @@ public abstract class EntityHumanType extends EntityCreature implements Inventor
     @Override
     protected void initEntity() {
         this.inventory = new PlayerInventory(this);
+        if (namedTag.containsNumber("SelectedInventorySlot")) {
+            this.inventory.setHeldItemSlot(NukkitMath.clamp(this.namedTag.getInt("SelectedInventorySlot"), 0, 8));
+        }
         this.offhandInventory = new PlayerOffhandInventory(this);
 
         if (this.namedTag.contains("Inventory") && this.namedTag.get("Inventory") instanceof ListTag) {
@@ -113,6 +116,8 @@ public abstract class EntityHumanType extends EntityCreature implements Inventor
                     inventoryTag.add(NBTIO.putItemHelper(item, slot));
                 }
             }
+            
+            this.namedTag.putInt("SelectedInventorySlot", this.inventory.getHeldItemIndex());
         }
 
         if (this.offhandInventory != null) {

--- a/src/main/java/cn/nukkit/entity/EntityLiving.java
+++ b/src/main/java/cn/nukkit/entity/EntityLiving.java
@@ -61,8 +61,6 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
 
     protected int turtleTicks = 200;
 
-    private boolean blocking = false;
-
     @Override
     protected void initEntity() {
         super.initEntity();
@@ -118,7 +116,7 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
             }
         }
 
-        if (this.blockedByShield(source)) {
+        if (isBlocking() && this.blockedByShield(source)) {
             return false;
         }
 
@@ -410,7 +408,12 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
     }
 
     protected boolean blockedByShield(EntityDamageEvent source) {
-        Entity damager = source instanceof EntityDamageByEntityEvent? ((EntityDamageByEntityEvent) source).getDamager() : null;
+        Entity damager = null;
+        if (source instanceof EntityDamageByChildEntityEvent) {
+            damager = ((EntityDamageByChildEntityEvent) source).getChild();
+        } else if (source instanceof EntityDamageByEntityEvent) {
+            damager = ((EntityDamageByEntityEvent) source).getDamager();
+        }
         if (damager == null || damager instanceof EntityWeather || !this.isBlocking()) {
             return false;
         }
@@ -450,12 +453,11 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
     }
 
     public boolean isBlocking() {
-        return this.blocking;
+        return this.getDataFlag(DATA_FLAGS_EXTENDED, DATA_FLAG_BLOCKING);
     }
 
     public void setBlocking(boolean value) {
-        this.blocking = value;
-        this.setDataFlag(DATA_FLAGS, DATA_FLAG_BLOCKING, value);
+        this.setDataFlag(DATA_FLAGS_EXTENDED, DATA_FLAG_BLOCKING, value);
     }
 
     @PowerNukkitOnly

--- a/src/main/java/cn/nukkit/entity/projectile/EntityArrow.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityArrow.java
@@ -84,6 +84,7 @@ public class EntityArrow extends EntityProjectile {
 
     public EntityArrow(FullChunk chunk, CompoundTag nbt, Entity shootingEntity, boolean critical) {
         super(chunk, nbt, shootingEntity);
+        closeOnCollide = false;
         this.setCritical(critical);
     }
 
@@ -150,6 +151,17 @@ public class EntityArrow extends EntityProjectile {
     @Override
     public boolean canBeMovedByCurrents() {
         return !hadCollision;
+    }
+
+    @Since("1.4.0.0-PN")
+    @PowerNukkitOnly
+    @Override
+    protected void afterCollisionWithEntity(Entity entity) {
+        if (hadCollision) {
+            close();
+        } else {
+            setMotion(getMotion().divide(-4));
+        }
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/projectile/EntityProjectile.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityProjectile.java
@@ -1,5 +1,6 @@
 package cn.nukkit.entity.projectile;
 
+import cn.nukkit.Player;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
@@ -157,7 +158,8 @@ public abstract class EntityProjectile extends Entity {
 
             for (Entity entity : list) {
                 if (/*!entity.canCollideWith(this) or */
-                        (entity == this.shootingEntity && this.ticksLived < 5)
+                        (entity == this.shootingEntity && this.ticksLived < 5) ||
+                                (entity instanceof Player && ((Player) entity).getGamemode() == Player.SPECTATOR)
                 ) {
                     continue;
                 }

--- a/src/main/java/cn/nukkit/entity/projectile/EntityProjectile.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityProjectile.java
@@ -92,9 +92,16 @@ public abstract class EntityProjectile extends Entity {
                 }
             }
         }
+        afterCollisionWithEntity(entity);
         if (closeOnCollide) {
             this.close();
         }
+    }
+    
+    @PowerNukkitOnly
+    @Since("1.4.0.0-PN")
+    protected void afterCollisionWithEntity(Entity entity) {
+        
     }
 
     @Override
@@ -186,7 +193,10 @@ public abstract class EntityProjectile extends Entity {
             if (movingObjectPosition != null) {
                 if (movingObjectPosition.entityHit != null) {
                     onCollideWithEntity(movingObjectPosition.entityHit);
-                    return true;
+                    hasUpdate = true;
+                    if (closed) {
+                        return true;
+                    }
                 }
             }
 

--- a/src/main/java/cn/nukkit/inventory/AnvilInventory.java
+++ b/src/main/java/cn/nukkit/inventory/AnvilInventory.java
@@ -2,8 +2,9 @@ package cn.nukkit.inventory;
 
 import cn.nukkit.Player;
 import cn.nukkit.api.DeprecationDetails;
-import cn.nukkit.block.Block;
+import cn.nukkit.block.BlockID;
 import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemID;
 import cn.nukkit.item.enchantment.Enchantment;
 import cn.nukkit.level.Position;
 import cn.nukkit.nbt.tag.CompoundTag;
@@ -362,73 +363,76 @@ public class AnvilInventory extends FakeBlockUIComponent {
     
     private static int getRepairMaterial(Item target) {
         switch (target.getId()) {
-            case Item.WOODEN_SWORD:
-            case Item.WOODEN_PICKAXE:
-            case Item.WOODEN_SHOVEL:
-            case Item.WOODEN_AXE:
-            case Item.WOODEN_HOE:
-                return Block.PLANKS;
+            case ItemID.WOODEN_SWORD:
+            case ItemID.WOODEN_PICKAXE:
+            case ItemID.WOODEN_SHOVEL:
+            case ItemID.WOODEN_AXE:
+            case ItemID.WOODEN_HOE:
+                return BlockID.PLANKS;
         
-            case Item.IRON_SWORD:
-            case Item.IRON_PICKAXE:
-            case Item.IRON_SHOVEL:
-            case Item.IRON_AXE:
-            case Item.IRON_HOE:
-            case Item.IRON_HELMET:
-            case Item.IRON_CHESTPLATE:
-            case Item.IRON_LEGGINGS:
-            case Item.IRON_BOOTS:
-            case Item.CHAIN_HELMET:
-            case Item.CHAIN_CHESTPLATE:
-            case Item.CHAIN_LEGGINGS:
-            case Item.CHAIN_BOOTS:
-                return Item.IRON_INGOT;
+            case ItemID.IRON_SWORD:
+            case ItemID.IRON_PICKAXE:
+            case ItemID.IRON_SHOVEL:
+            case ItemID.IRON_AXE:
+            case ItemID.IRON_HOE:
+            case ItemID.IRON_HELMET:
+            case ItemID.IRON_CHESTPLATE:
+            case ItemID.IRON_LEGGINGS:
+            case ItemID.IRON_BOOTS:
+            case ItemID.CHAIN_HELMET:
+            case ItemID.CHAIN_CHESTPLATE:
+            case ItemID.CHAIN_LEGGINGS:
+            case ItemID.CHAIN_BOOTS:
+                return ItemID.IRON_INGOT;
         
-            case Item.GOLD_SWORD:
-            case Item.GOLD_PICKAXE:
-            case Item.GOLD_SHOVEL:
-            case Item.GOLD_AXE:
-            case Item.GOLD_HOE:
-            case Item.GOLD_HELMET:
-            case Item.GOLD_CHESTPLATE:
-            case Item.GOLD_LEGGINGS:
-            case Item.GOLD_BOOTS:
-                return Item.GOLD_INGOT;
+            case ItemID.GOLD_SWORD:
+            case ItemID.GOLD_PICKAXE:
+            case ItemID.GOLD_SHOVEL:
+            case ItemID.GOLD_AXE:
+            case ItemID.GOLD_HOE:
+            case ItemID.GOLD_HELMET:
+            case ItemID.GOLD_CHESTPLATE:
+            case ItemID.GOLD_LEGGINGS:
+            case ItemID.GOLD_BOOTS:
+                return ItemID.GOLD_INGOT;
         
-            case Item.DIAMOND_SWORD:
-            case Item.DIAMOND_PICKAXE:
-            case Item.DIAMOND_SHOVEL:
-            case Item.DIAMOND_AXE:
-            case Item.DIAMOND_HOE:
-            case Item.DIAMOND_HELMET:
-            case Item.DIAMOND_CHESTPLATE:
-            case Item.DIAMOND_LEGGINGS:
-            case Item.DIAMOND_BOOTS:
-                return Item.DIAMOND;
+            case ItemID.DIAMOND_SWORD:
+            case ItemID.DIAMOND_PICKAXE:
+            case ItemID.DIAMOND_SHOVEL:
+            case ItemID.DIAMOND_AXE:
+            case ItemID.DIAMOND_HOE:
+            case ItemID.DIAMOND_HELMET:
+            case ItemID.DIAMOND_CHESTPLATE:
+            case ItemID.DIAMOND_LEGGINGS:
+            case ItemID.DIAMOND_BOOTS:
+                return ItemID.DIAMOND;
         
-            case Item.LEATHER_CAP:
-            case Item.LEATHER_TUNIC:
-            case Item.LEATHER_PANTS:
-            case Item.LEATHER_BOOTS:
-                return Item.LEATHER;
+            case ItemID.LEATHER_CAP:
+            case ItemID.LEATHER_TUNIC:
+            case ItemID.LEATHER_PANTS:
+            case ItemID.LEATHER_BOOTS:
+                return ItemID.LEATHER;
                 
-            case Item.STONE_SWORD:
-            case Item.STONE_PICKAXE:
-            case Item.STONE_SHOVEL:
-            case Item.STONE_AXE:
-            case Item.STONE_HOE:
-                return Item.COBBLESTONE;
+            case ItemID.STONE_SWORD:
+            case ItemID.STONE_PICKAXE:
+            case ItemID.STONE_SHOVEL:
+            case ItemID.STONE_AXE:
+            case ItemID.STONE_HOE:
+                return BlockID.COBBLESTONE;
 
-            case Item.NETHERITE_SWORD:
-            case Item.NETHERITE_PICKAXE:
-            case Item.NETHERITE_SHOVEL:
-            case Item.NETHERITE_AXE:
-            case Item.NETHERITE_HOE:
-            case Item.NETHERITE_HELMET:
-            case Item.NETHERITE_CHESTPLATE:
-            case Item.NETHERITE_LEGGINGS:
-            case Item.NETHERITE_BOOTS:
-                return Item.NETHERITE_INGOT;
+            case ItemID.NETHERITE_SWORD:
+            case ItemID.NETHERITE_PICKAXE:
+            case ItemID.NETHERITE_SHOVEL:
+            case ItemID.NETHERITE_AXE:
+            case ItemID.NETHERITE_HOE:
+            case ItemID.NETHERITE_HELMET:
+            case ItemID.NETHERITE_CHESTPLATE:
+            case ItemID.NETHERITE_LEGGINGS:
+            case ItemID.NETHERITE_BOOTS:
+                return ItemID.NETHERITE_INGOT;
+                
+            case ItemID.ELYTRA:
+                return ItemID.PHANTOM_MEMBRANE;
 
             default:
                 return 0;

--- a/src/main/java/cn/nukkit/inventory/transaction/CraftingTransaction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/CraftingTransaction.java
@@ -130,6 +130,9 @@ public class CraftingTransaction extends InventoryTransaction {
                     }
                 }
             }
+            if (recipe == null) {
+                source.sendExperienceLevel();
+            }
             source.getUIInventory().setItem(AnvilInventory.RESULT, Item.get(0), false);
         } else if (craftingType == Player.CRAFTING_GRINDSTONE) {
             Inventory inventory = source.getWindowById(Player.GRINDSTONE_WINDOW_ID);

--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -1085,7 +1085,7 @@ public class Item implements Cloneable, BlockID, ItemID {
     }
 
     public int getMaxStackSize() {
-        return 64;
+        return block == null? 64 : block.getItemMaxStackSize();
     }
 
     final public Short getFuelTime() {

--- a/src/main/java/cn/nukkit/level/format/generic/BaseChunk.java
+++ b/src/main/java/cn/nukkit/level/format/generic/BaseChunk.java
@@ -64,7 +64,26 @@ public abstract class BaseChunk extends BaseFullChunk implements Chunk {
 
     private void removeInvalidTile(int x, int y, int z) {
         BlockEntity entity = getTile(x, y, z);
-        if (entity != null && !entity.isBlockEntityValid()) {
+        if (entity != null) {
+            try {
+                if (!entity.closed && entity.isBlockEntityValid()) {
+                    return;
+                }
+            } catch (Exception e) {
+                try {
+                    log.warn("Block entity validation of {} at {}, {} {} {} failed, removing as invalid.",
+                            entity.getClass().getName(),
+                            getProvider().getLevel().getName(),
+                            entity.x,
+                            entity.y,
+                            entity.z,
+                            e
+                    );
+                } catch (Exception e2) {
+                    e.addSuppressed(e2);
+                    log.warn("Block entity validation failed", e);
+                }
+            }
             removeBlockEntity(entity);
         }
     }


### PR DESCRIPTION
- [x] Hanging lantern not dropping when the block above is broken
- [x] Fix: Exceptions when trying to place moving_block as an item
- [x] Fix: Experience level desync when anvil crafting is canceled
- [x] #626 Can't repair Elytra with Phantom Membrane in Anvil
- [x] Fix: /give not parsing `@p`
- [x] Fix: /give accepting negative amounts
- [x] Fix: /give not giving all items when the inventory is full
- [x] #495 /give allowing to give ItemBlock of BlockUnknown
- [x] Projectiles could hit players in spectator mode
- [x] #606 Shield protecting even when in cooldown
- [x] #607 Shield knockbacking the shooter of the arrow instead of the arrow