### PR TITLE
Fix: WallUpdater exception when updating walls with invalid type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,16 @@
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
+    
+    <repositories>
+        <repository>
+            <id>powernukkit-snapshots</id>
+            <name>powernukkit-snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases><enabled>false</enabled></releases>
+            <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+    </repositories>
 
     <dependencies>
         <dependency>
@@ -97,6 +107,12 @@
             <artifactId>raknet</artifactId>
             <version>1.6.15-PN2</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powernukkit</groupId>
+            <artifactId>powernukkit-tests-junit5</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powernukkit.fastutil</groupId>

--- a/src/main/java/cn/nukkit/blockproperty/BlockProperty.java
+++ b/src/main/java/cn/nukkit/blockproperty/BlockProperty.java
@@ -475,4 +475,14 @@ public abstract class BlockProperty<T extends Serializable> implements Serializa
     public boolean isExportedToItem() {
         return exportedToItem;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName()+"{" +
+                "name='" + name + '\'' +
+                ", bitSize=" + bitSize +
+                ", exportedToItem=" + exportedToItem +
+                ", persistenceName='" + persistenceName + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -4126,7 +4126,15 @@ public class Level implements ChunkManager, Metadatable {
 
         return false;
     }
-    
+
+    @Override
+    public String toString() {
+        return "Level{" +
+                "folderName='" + folderName + '\'' +
+                ", dimension=" + dimension +
+                '}';
+    }
+
     @AllArgsConstructor
     @Data
     private static class QueuedUpdate {

--- a/src/main/java/cn/nukkit/level/format/updater/ChunkUpdater.java
+++ b/src/main/java/cn/nukkit/level/format/updater/ChunkUpdater.java
@@ -44,18 +44,17 @@ public class ChunkUpdater {
             }
             
             if (section.getContentVersion() < 5) {
-                updated = updateToV9FromV0toV5(level, chunk, updated, section, section.getContentVersion());
+                updated = updateToV8FromV0toV5(level, chunk, updated, section, section.getContentVersion());
             } else if (section.getContentVersion() == 5 || section.getContentVersion() == 7) {
-                updated = updateBeehiveToV8(chunk, updated, section, false);
+                updated = updateBeehiveFromV5or6or7toV8(chunk, updated, section, false);
             } else if (section.getContentVersion() == 6) {
-                updated = updateBeehiveToV8(chunk, updated, section, true);
+                updated = updateBeehiveFromV5or6or7toV8(chunk, updated, section, true);
             } 
             if (section.getContentVersion() == 8) {
-                updated = walk(chunk, section, new WallUpdater(level, section)) || updated;
-                section.setContentVersion(9);
+                updated = upgradeWallsFromV8toV9(level, chunk, updated, section);
             }
             if (section.getContentVersion() == 9) {
-                updated = upgradeSnowLayersToV10(level, chunk, updated, section);
+                updated = upgradeSnowLayersFromV9toV10(level, chunk, updated, section);
             }
         }
 
@@ -63,8 +62,14 @@ public class ChunkUpdater {
             chunk.setChanged();
         }
     }
-    
-    private boolean upgradeSnowLayersToV10(Level level, BaseChunk chunk, boolean updated, ChunkSection section) {
+
+    private boolean upgradeWallsFromV8toV9(Level level, BaseChunk chunk, boolean updated, ChunkSection section) {
+        updated = walk(chunk, section, new WallUpdater(level, section)) || updated;
+        section.setContentVersion(9);
+        return updated;
+    }
+
+    private boolean upgradeSnowLayersFromV9toV10(Level level, BaseChunk chunk, boolean updated, ChunkSection section) {
         updated |= walk(chunk, section, new GroupedUpdaters(
                 new NewLeafUpdater(section),
                 new SnowLayerUpdater(level, section)
@@ -73,7 +78,7 @@ public class ChunkUpdater {
         return updated;
     }
     
-    private boolean updateBeehiveToV8(BaseChunk chunk, boolean updated, ChunkSection section, boolean updateDirection) {
+    private boolean updateBeehiveFromV5or6or7toV8(BaseChunk chunk, boolean updated, ChunkSection section, boolean updateDirection) {
         if (walk(chunk, section, new BeehiveUpdater(section, updateDirection))) {
             updated = true;
         }
@@ -81,7 +86,7 @@ public class ChunkUpdater {
         return updated;
     }
 
-    private boolean updateToV9FromV0toV5(Level level, BaseChunk chunk, boolean updated, ChunkSection section, int contentVersion) {
+    private boolean updateToV8FromV0toV5(Level level, BaseChunk chunk, boolean updated, ChunkSection section, int contentVersion) {
         WallUpdater wallUpdater = new WallUpdater(level, section);
         boolean sectionUpdated = walk(chunk, section, new GroupedUpdaters(
                 new MesaBiomeUpdater(section),

--- a/src/test/java/cn/nukkit/level/format/updater/WallUpdaterTest.java
+++ b/src/test/java/cn/nukkit/level/format/updater/WallUpdaterTest.java
@@ -1,0 +1,71 @@
+/*
+ * https://PowerNukkit.org - The Nukkit you know but Powerful!
+ * Copyright (C) 2020  José Roberto de Araújo Júnior
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cn.nukkit.level.format.updater;
+
+import cn.nukkit.block.Block;
+import cn.nukkit.block.BlockID;
+import cn.nukkit.block.BlockWall;
+import cn.nukkit.blockstate.BlockState;
+import cn.nukkit.level.Level;
+import cn.nukkit.level.format.anvil.ChunkSection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.powernukkit.tests.api.MockLevel;
+import org.powernukkit.tests.junit.jupiter.PowerNukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author joserobjr
+ * @since 2020-09-20
+ */
+@ExtendWith(PowerNukkitExtension.class)
+class WallUpdaterTest implements BlockID {
+    int x = 3, y = 4, z = 5;
+    
+    @MockLevel
+    Level level;
+
+    ChunkSection section;
+    
+    WallUpdater updater;
+
+    @Test
+    void update() {
+        BlockState state = BlockState.of(COBBLE_WALL, 63);
+        section.setBlockState(x, y, z, state);
+        assertTrue(updater.update(0, 0, 0, x, y, z, state));
+        BlockWall wall = new BlockWall();
+        wall.setWallPost(true);
+        Block actual = section.getBlockState(x, y, z).getBlock();
+        assertEquals(wall.getCurrentState(), section.getBlockState(x, y, z));
+        assertEquals(wall.getCurrentState(), actual.getCurrentState());
+    }
+
+    @BeforeEach
+    void setUp() {
+        section = new ChunkSection(0);
+        section.setContentVersion(0);
+        section.delayPaletteUpdates();
+        
+        updater = new WallUpdater(level, section);
+    }
+}


### PR DESCRIPTION
```java
> 00:27:31 [WARN ] Failed to update the block X:-198, Y:86, Z:-184 at cn.nukkit.level.Level@301b89e1, could not cast it to BlockWall.
cn.nukkit.blockstate.exception.InvalidBlockStateException: The block state BlockState(blockId=139, storage=63) is invalid: Invalid block state in layer 0 at: Position(level=world,x=-198.0,y=86.0,z=-184.0)
BlockProperties{bitSize=13, properties=[0-4:wall_block_type, 4-6:wall_connection_type_south, 6-8:wall_connection_type_west, 8-10:wall_connection_type_north, 10-12:wall_connection_type_east, 12-13:wall_post_bit]}
at cn.nukkit.blockstate.IBlockState.getBlock(IBlockState.java:271) ~[server.jar:?]
at cn.nukkit.blockstate.BlockState.getBlock(BlockState.java:438) ~[server.jar:?]
at cn.nukkit.blockstate.IBlockState.getBlock(IBlockState.java:232) ~[server.jar:?]
at cn.nukkit.level.format.updater.WallUpdater.update(WallUpdater.java:30) [server.jar:?]
at cn.nukkit.level.format.updater.ChunkUpdater.walk(ChunkUpdater.java:125) [server.jar:?]
at cn.nukkit.level.format.updater.ChunkUpdater.backwardCompatibilityUpdate(ChunkUpdater.java:54) [server.jar:?]
at cn.nukkit.level.format.generic.BaseChunk.backwardCompatibilityUpdate(BaseChunk.java:48) [server.jar:?]
at cn.nukkit.level.Level.forceLoadChunk(Level.java:3177) [server.jar:?]
at cn.nukkit.level.Level.getChunk(Level.java:2820) [server.jar:?]
at cn.nukkit.level.Level.getChunk(Level.java:2813) [server.jar:?]
at cn.nukkit.level.Level.getBlock(Level.java:1655) [server.jar:?]
at cn.nukkit.level.Level.getBlock(Level.java:1640) [server.jar:?]
at cn.nukkit.block.Block.getSideAtLayer(Block.java:1440) [server.jar:?]
at cn.nukkit.block.BlockWallBase.autoConfigureState(BlockWallBase.java:155) [server.jar:?]
at cn.nukkit.level.format.updater.WallUpdater.update(WallUpdater.java:44) [server.jar:?]
at cn.nukkit.level.format.updater.ChunkUpdater.walk(ChunkUpdater.java:125) [server.jar:?]
at cn.nukkit.level.format.updater.ChunkUpdater.backwardCompatibilityUpdate(ChunkUpdater.java:54) [server.jar:?]
at cn.nukkit.level.format.generic.BaseChunk.backwardCompatibilityUpdate(BaseChunk.java:48) [server.jar:?]
at cn.nukkit.level.Level.forceLoadChunk(Level.java:3177) [server.jar:?]
at cn.nukkit.level.Level.getChunk(Level.java:2820) [server.jar:?]
at cn.nukkit.level.Level.populateChunk(Level.java:3389) [server.jar:?]
at cn.nukkit.Player.sendNextChunk(Player.java:853) [server.jar:?]
at cn.nukkit.Player.checkNetwork(Player.java:1995) [server.jar:?]
at cn.nukkit.Server.tick(Server.java:1358) [server.jar:?]
at cn.nukkit.Server.tickProcessor(Server.java:1127) [server.jar:?]
at cn.nukkit.Server.start(Server.java:1095) [server.jar:?]
at cn.nukkit.Server.<init>(Server.java:751) [server.jar:?]
at cn.nukkit.Nukkit.main(Nukkit.java:120) [server.jar:?]
Suppressed: cn.nukkit.blockstate.exception.InvalidBlockStateException: The block state BlockState(blockId=139, storage=15) is invalid: Invalid block state in layer 0 at: Position(level=world,x=-198.0,y=86.0,z=-184.0)
BlockProperties{bitSize=13, properties=[0-4:wall_block_type, 4-6:wall_connection_type_south, 6-8:wall_connection_type_west, 8-10:wall_connection_type_north, 10-12:wall_connection_type_east, 12-13:wall_post_bit]}
at cn.nukkit.blockstate.IBlockState.getBlock(IBlockState.java:271) ~[server.jar:?]
at cn.nukkit.blockstate.BlockState.getBlock(BlockState.java:438) ~[server.jar:?]
at cn.nukkit.blockstate.IBlockState.getBlock(IBlockState.java:232) ~[server.jar:?]
at cn.nukkit.level.format.updater.WallUpdater.update(WallUpdater.java:34) [server.jar:?]
at cn.nukkit.level.format.updater.ChunkUpdater.walk(ChunkUpdater.java:125) [server.jar:?]
at cn.nukkit.level.format.updater.ChunkUpdater.backwardCompatibilityUpdate(ChunkUpdater.java:54) [server.jar:?]
at cn.nukkit.level.format.generic.BaseChunk.backwardCompatibilityUpdate(BaseChunk.java:48) [server.jar:?]
at cn.nukkit.level.Level.forceLoadChunk(Level.java:3177) [server.jar:?]
at cn.nukkit.level.Level.getChunk(Level.java:2820) [server.jar:?]
at cn.nukkit.level.Level.getChunk(Level.java:2813) [server.jar:?]
at cn.nukkit.level.Level.getBlock(Level.java:1655) [server.jar:?]
at cn.nukkit.level.Level.getBlock(Level.java:1640) [server.jar:?]
at cn.nukkit.block.Block.getSideAtLayer(Block.java:1440) [server.jar:?]
at cn.nukkit.block.BlockWallBase.autoConfigureState(BlockWallBase.java:155) [server.jar:?]
at cn.nukkit.level.format.updater.WallUpdater.update(WallUpdater.java:44) [server.jar:?]
at cn.nukkit.level.format.updater.ChunkUpdater.walk(ChunkUpdater.java:125) [server.jar:?]
at cn.nukkit.level.format.updater.ChunkUpdater.backwardCompatibilityUpdate(ChunkUpdater.java:54) [server.jar:?]
at cn.nukkit.level.format.generic.BaseChunk.backwardCompatibilityUpdate(BaseChunk.java:48) [server.jar:?]
at cn.nukkit.level.Level.forceLoadChunk(Level.java:3177) [server.jar:?]
at cn.nukkit.level.Level.getChunk(Level.java:2820) [server.jar:?]
at cn.nukkit.level.Level.populateChunk(Level.java:3398) [server.jar:?]
at cn.nukkit.level.Level.populateChunk(Level.java:3389) [server.jar:?]
at cn.nukkit.Player.sendNextChunk(Player.java:853) [server.jar:?]
at cn.nukkit.Player.checkNetwork(Player.java:1995) [server.jar:?]
at cn.nukkit.Server.tick(Server.java:1358) [server.jar:?]
at cn.nukkit.Server.tickProcessor(Server.java:1127) [server.jar:?]
at cn.nukkit.Server.start(Server.java:1095) [server.jar:?]
at cn.nukkit.Server.<init>(Server.java:751) [server.jar:?]
at cn.nukkit.Nukkit.main(Nukkit.java:120) [server.jar:?]
Caused by: cn.nukkit.blockstate.exception.InvalidBlockStateException: The block state BlockState(blockId=139, storage=15) is invalid
BlockProperties{bitSize=13, properties=[0-4:wall_block_type, 4-6:wall_connection_type_south, 6-8:wall_connection_type_west, 8-10:wall_connection_type_north, 10-12:wall_connection_type_east, 12-13:wall_post_bit]}
at cn.nukkit.blockstate.IntMutableBlockState.validate(IntMutableBlockState.java:136) ~[server.jar:?]
at cn.nukkit.blockstate.IntMutableBlockState.setDataStorageFromInt(IntMutableBlockState.java:99) ~[server.jar:?]
at cn.nukkit.blockstate.IntMutableBlockState.setDataStorage(IntMutableBlockState.java:92) ~[server.jar:?]
at cn.nukkit.blockstate.IMutableBlockState.setDataStorage(IMutableBlockState.java:89) ~[server.jar:?]
at cn.nukkit.block.Block.setDataStorage(Block.java:1912) ~[server.jar:?]
at cn.nukkit.blockstate.IBlockState.getBlock(IBlockState.java:269) ~[server.jar:?]
... 28 more
Caused by: cn.nukkit.blockproperty.exception.InvalidBlockPropertyMetaException: Property: wall_block_type. Current Meta: 15, Invalid Meta: 15
at cn.nukkit.blockproperty.BlockProperty.validateMeta(BlockProperty.java:414) ~[server.jar:?]
at cn.nukkit.blockstate.IntMutableBlockState.validate(IntMutableBlockState.java:133) ~[server.jar:?]
at cn.nukkit.blockstate.IntMutableBlockState.setDataStorageFromInt(IntMutableBlockState.java:99) ~[server.jar:?]
at cn.nukkit.blockstate.IntMutableBlockState.setDataStorage(IntMutableBlockState.java:92) ~[server.jar:?]
at cn.nukkit.blockstate.IMutableBlockState.setDataStorage(IMutableBlockState.java:89) ~[server.jar:?]
at cn.nukkit.block.Block.setDataStorage(Block.java:1912) ~[server.jar:?]
at cn.nukkit.blockstate.IBlockState.getBlock(IBlockState.java:269) ~[server.jar:?]
... 28 more
Caused by: java.lang.IndexOutOfBoundsException: index (15) must be less than size (14)
at com.google.common.base.Preconditions.checkElementIndex(Preconditions.java:1348) ~[server.jar:?]
at com.google.common.base.Preconditions.checkElementIndex(Preconditions.java:1330) ~[server.jar:?]
at cn.nukkit.blockproperty.ArrayBlockProperty.validateMetaDirectly(ArrayBlockProperty.java:176) ~[server.jar:?]
at cn.nukkit.blockproperty.BlockProperty.validateMeta(BlockProperty.java:412) ~[server.jar:?]
at cn.nukkit.blockstate.IntMutableBlockState.validate(IntMutableBlockState.java:133) ~[server.jar:?]
at cn.nukkit.blockstate.IntMutableBlockState.setDataStorageFromInt(IntMutableBlockState.java:99) ~[server.jar:?]
at cn.nukkit.blockstate.IntMutableBlockState.setDataStorage(IntMutableBlockState.java:92) ~[server.jar:?]
at cn.nukkit.blockstate.IMutableBlockState.setDataStorage(IMutableBlockState.java:89) ~[server.jar:?]
at cn.nukkit.block.Block.setDataStorage(Block.java:1912) ~[server.jar:?]
at cn.nukkit.blockstate.IBlockState.getBlock(IBlockState.java:269) ~[server.jar:?]
... 28 more
Caused by: cn.nukkit.blockstate.exception.InvalidBlockStateException: The block state BlockState(blockId=139, storage=63) is invalid
BlockProperties{bitSize=13, properties=[0-4:wall_block_type, 4-6:wall_connection_type_south, 6-8:wall_connection_type_west, 8-10:wall_connection_type_north, 10-12:wall_connection_type_east, 12-13:wall_post_bit]}
at cn.nukkit.blockstate.IntMutableBlockState.validate(IntMutableBlockState.java:136) ~[server.jar:?]
at cn.nukkit.blockstate.IntMutableBlockState.setDataStorageFromInt(IntMutableBlockState.java:99) ~[server.jar:?]
at cn.nukkit.blockstate.IntMutableBlockState.setDataStorage(IntMutableBlockState.java:92) ~[server.jar:?]
at cn.nukkit.blockstate.IMutableBlockState.setDataStorage(IMutableBlockState.java:89) ~[server.jar:?]
at cn.nukkit.block.Block.setDataStorage(Block.java:1912) ~[server.jar:?]
at cn.nukkit.blockstate.IBlockState.getBlock(IBlockState.java:269) ~[server.jar:?]
... 28 more
Caused by: cn.nukkit.blockproperty.exception.InvalidBlockPropertyMetaException: Property: wall_block_type. Current Meta: 63, Invalid Meta: 15
at cn.nukkit.blockproperty.BlockProperty.validateMeta(BlockProperty.java:414) ~[server.jar:?]
at cn.nukkit.blockstate.IntMutableBlockState.validate(IntMutableBlockState.java:133) ~[server.jar:?]
at cn.nukkit.blockstate.IntMutableBlockState.setDataStorageFromInt(IntMutableBlockState.java:99) ~[server.jar:?]
at cn.nukkit.blockstate.IntMutableBlockState.setDataStorage(IntMutableBlockState.java:92) ~[server.jar:?]
at cn.nukkit.blockstate.IMutableBlockState.setDataStorage(IMutableBlockState.java:89) ~[server.jar:?]
at cn.nukkit.block.Block.setDataStorage(Block.java:1912) ~[server.jar:?]
at cn.nukkit.blockstate.IBlockState.getBlock(IBlockState.java:269) ~[server.jar:?]
... 28 more
Caused by: java.lang.IndexOutOfBoundsException: index (15) must be less than size (14)
at com.google.common.base.Preconditions.checkElementIndex(Preconditions.java:1348) ~[server.jar:?]
at com.google.common.base.Preconditions.checkElementIndex(Preconditions.java:1330) ~[server.jar:?]
at cn.nukkit.blockproperty.ArrayBlockProperty.validateMetaDirectly(ArrayBlockProperty.java:176) ~[server.jar:?]
at cn.nukkit.blockproperty.BlockProperty.validateMeta(BlockProperty.java:412) ~[server.jar:?]
at cn.nukkit.blockstate.IntMutableBlockState.validate(IntMutableBlockState.java:133) ~[server.jar:?]
at cn.nukkit.blockstate.IntMutableBlockState.setDataStorageFromInt(IntMutableBlockState.java:99) ~[server.jar:?]
at cn.nukkit.blockstate.IntMutableBlockState.setDataStorage(IntMutableBlockState.java:92) ~[server.jar:?]
at cn.nukkit.blockstate.IMutableBlockState.setDataStorage(IMutableBlockState.java:89) ~[server.jar:?]
at cn.nukkit.block.Block.setDataStorage(Block.java:1912) ~[server.jar:?]
at cn.nukkit.blockstate.IBlockState.getBlock(IBlockState.java:269) ~[server.jar:?]
... 28 more
```