### PR TITLE
Add option that set players skin trusted

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2333,7 +2333,11 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         this.close("", "disconnectionScreen.invalidSkin");
                         break;
                     } else {
-                        this.setSkin(this.server.isForceSkinTrusted() ? loginPacket.skin.setTrusted(true) : loginPacket.skin);
+                        Skin skin = loginPacket.skin;
+                        if (this.server.isForceSkinTrusted()) {
+                            skin.setTrusted(true);
+                        }
+                        this.setSkin(skin);
                     }
 
                     PlayerPreLoginEvent playerPreLoginEvent;
@@ -2442,6 +2446,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
                     if (!skin.isValid()) {
                         break;
+                    }
+
+                    if (this.server.isForceSkinTrusted()) {
+                        skin.setTrusted(true);
                     }
 
                     PlayerChangeSkinEvent playerChangeSkinEvent = new PlayerChangeSkinEvent(this, skin);

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2333,7 +2333,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         this.close("", "disconnectionScreen.invalidSkin");
                         break;
                     } else {
-                        this.setSkin(loginPacket.skin);
+                        this.setSkin(this.server.isForceSkinTrusted() ? loginPacket.skin.setTrusted(true) : loginPacket.skin);
                     }
 
                     PlayerPreLoginEvent playerPreLoginEvent;

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -259,6 +259,8 @@ public class Server {
 
     private boolean safeSpawn;
 
+    private boolean forceSkinTrusted = false;
+
     /**
      * Minimal initializer for testing
      */
@@ -562,7 +564,9 @@ public class Server {
         this.alwaysTickPlayers = this.getConfig("level-settings.always-tick-players", false);
         this.baseTickRate = this.getConfig("level-settings.base-tick-rate", 1);
         this.redstoneEnabled = this.getConfig("level-settings.tick-redstone", true);
-        this.safeSpawn = this.getConfig().getBoolean("settings.safe-spawn",true);
+        this.safeSpawn = this.getConfig().getBoolean("settings.safe-spawn", true);
+        this.forceSkinTrusted = this.getConfig().getBoolean("player.force-skin-trusted", false);
+
         this.scheduler = new ServerScheduler();
 
         if (this.getPropertyBoolean("enable-rcon", false)) {
@@ -2624,6 +2628,12 @@ public class Server {
     @Nonnull
     public PositionTrackingService getPositionTrackingService() {
         return positionTrackingService;
+    }
+
+    @PowerNukkitOnly
+    @Since("1.4.0.0-PN")
+    public boolean isForceSkinTrusted(){
+        return forceSkinTrusted;
     }
 
     private class ConsoleThread extends Thread implements InterruptibleThread {

--- a/src/main/resources/default-nukkit.yml
+++ b/src/main/resources/default-nukkit.yml
@@ -64,6 +64,7 @@ spawn-limits:
 player:
  save-player-data: true
  skin-change-cooldown: 30
+ force-skin-trusted: false
 
 aliases:
 


### PR DESCRIPTION
Add option that set players skin trusted.

If you enable this option in `nukkit.yml` (force-skin-trusted), every player skin will be trusted. (It doesn't affect when you change player's skin with plugin. It only affect login packet and player skin packet in cn.nukkit.Player.)