### PR TITLE
Fixes reduntant sendWeather call being sent to client.

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -974,7 +974,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         if (this.level.isRaining() || this.level.isThundering()) {
             this.getLevel().sendWeather(this);
         }
-        this.getLevel().sendWeather(this);
 
         //FoodLevel
         PlayerFood food = this.getFoodData();


### PR DESCRIPTION
The client defaults to `clear` when no weather is sent, an optimization was done long ago but forgot
to remove the previous unoptimized call leading to it sending two packages at times, and always sending at least one.