### PR TITLE
Fix Boat problems

### DIFF
--- a/src/main/java/cn/nukkit/entity/item/EntityBoat.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityBoat.java
@@ -17,7 +17,6 @@ import cn.nukkit.item.ItemBoat;
 import cn.nukkit.level.GameRule;
 import cn.nukkit.level.Location;
 import cn.nukkit.level.format.FullChunk;
-import cn.nukkit.level.particle.SmokeParticle;
 import cn.nukkit.math.AxisAlignedBB;
 import cn.nukkit.math.NukkitMath;
 import cn.nukkit.math.Vector3;
@@ -129,9 +128,6 @@ public class EntityBoat extends EntityVehicle {
         for (Entity linkedEntity : this.passengers) {
             linkedEntity.riding = null;
         }
-
-        SmokeParticle particle = new SmokeParticle(this);
-        this.level.addParticle(particle);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/item/EntityBoat.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityBoat.java
@@ -35,8 +35,8 @@ import java.util.ArrayList;
 public class EntityBoat extends EntityVehicle {
 
     public static final int NETWORK_ID = 90;
-
-    public static final int DATA_WOOD_ID = 20;
+    
+    protected int variant;
 
     public static final Vector3f RIDER_PLAYER_OFFSET = new Vector3f(0, 1.02001f, 0);
     public static final Vector3f RIDER_OFFSET = new Vector3f(0, -0.2f, 0);
@@ -63,8 +63,11 @@ public class EntityBoat extends EntityVehicle {
     @Override
     protected void initEntity() {
         super.initEntity();
-
-        this.dataProperties.putByte(DATA_WOOD_ID, this.namedTag.getByte("woodID"));
+        
+        if (this.namedTag.contains("Variant")) {
+            this.variant = this.namedTag.getInt("Variant");
+        }
+        this.dataProperties.putInt(DATA_VARIANT, this.variant);
     }
 
     @Override
@@ -427,5 +430,20 @@ public class EntityBoat extends EntityVehicle {
         if (level.getGameRules().getBoolean(GameRule.DO_ENTITY_DROPS)) {
             this.level.dropItem(this, new ItemBoat());
         }
+    }
+    
+    @Override
+    public void saveNBT() {
+        super.saveNBT();
+        this.namedTag.putInt("Variant", this.variant);
+    }
+    
+    public int getVariant() {
+        return this.variant;
+    }
+    
+    public void setVariant(int variant) {
+        this.variant = variant;
+        this.dataProperties.putInt(DATA_VARIANT, variant);
     }
 }

--- a/src/main/java/cn/nukkit/entity/item/EntityBoat.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityBoat.java
@@ -13,7 +13,7 @@ import cn.nukkit.event.entity.EntityDamageEvent;
 import cn.nukkit.event.vehicle.VehicleMoveEvent;
 import cn.nukkit.event.vehicle.VehicleUpdateEvent;
 import cn.nukkit.item.Item;
-import cn.nukkit.item.itemID;
+import cn.nukkit.item.ItemID;
 import cn.nukkit.level.GameRule;
 import cn.nukkit.level.Location;
 import cn.nukkit.level.format.FullChunk;

--- a/src/main/java/cn/nukkit/entity/item/EntityBoat.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityBoat.java
@@ -13,7 +13,7 @@ import cn.nukkit.event.entity.EntityDamageEvent;
 import cn.nukkit.event.vehicle.VehicleMoveEvent;
 import cn.nukkit.event.vehicle.VehicleUpdateEvent;
 import cn.nukkit.item.Item;
-import cn.nukkit.item.ItemBoat;
+import cn.nukkit.item.itemID;
 import cn.nukkit.level.GameRule;
 import cn.nukkit.level.Location;
 import cn.nukkit.level.format.FullChunk;
@@ -424,7 +424,7 @@ public class EntityBoat extends EntityVehicle {
         super.kill();
 
         if (level.getGameRules().getBoolean(GameRule.DO_ENTITY_DROPS)) {
-            this.level.dropItem(this, new ItemBoat());
+            this.level.dropItem(this, Item.get(ItemID.BOAT, this.variant));
         }
     }
     

--- a/src/main/java/cn/nukkit/item/ItemBoat.java
+++ b/src/main/java/cn/nukkit/item/ItemBoat.java
@@ -51,7 +51,7 @@ public class ItemBoat extends Item {
                 .putList(new ListTag<FloatTag>("Rotation")
                         .add(new FloatTag("", (float) ((player.yaw + 90f) % 360)))
                         .add(new FloatTag("", 0)))
-                .putByte("woodID", this.getDamage())
+                .putInt("Variant", this.getDamage())
         );
 
         if (boat == null) {

--- a/src/main/java/cn/nukkit/item/ItemBoat.java
+++ b/src/main/java/cn/nukkit/item/ItemBoat.java
@@ -58,7 +58,7 @@ public class ItemBoat extends Item {
             return false;
         }
 
-        if (player.isSurvival()) {
+        if (player.isSurvival() || player.isAdventure()) {
             Item item = player.getInventory().getItemInHand();
             item.setCount(item.getCount() - 1);
             player.getInventory().setItemInHand(item);


### PR DESCRIPTION
Fix Boat problems.

Changed:
  - Boat use Variant instead of woodID.
    - Save Variant.
    - New method: getVariant(), setVariant(int variant)
    - Drop boat item properly when it killed.
  - Boat doesn't make Smoke particles.
  - Use Variant tag when spawning. (ItemBoat)
  - Reduce ItemBoat count in Adventure mode.