### PR TITLE
Fixing BlockEntity of some blocks + another piston fix

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockNoteblock.java
+++ b/src/main/java/cn/nukkit/block/BlockNoteblock.java
@@ -263,7 +263,13 @@ public class BlockNoteblock extends BlockSolid implements BlockEntityHolder<Bloc
     @Override
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_REDSTONE) {
-            BlockEntityMusic music = getOrCreateBlockEntity();
+            // We can't use getOrCreateBlockEntity(), because the update method is called on block place,
+            // before the "real" BlockEntity is set. That means, if we'd use the other method here,
+            // it would create two BlockEntities.
+            BlockEntityMusic music = getBlockEntity();
+            if (music == null)
+                return 0;
+
             if (this.getLevel().isBlockPowered(this)) {
                 if (!music.isPowered()) {
                     this.emitSound();

--- a/src/main/java/cn/nukkit/block/BlockPistonBase.java
+++ b/src/main/java/cn/nukkit/block/BlockPistonBase.java
@@ -94,7 +94,7 @@ public abstract class BlockPistonBase extends BlockSolidMeta implements Faceable
                 this.setDamage(player.getHorizontalFacing().getIndex());
             }
         }
-        
+
         if(this.level.getBlockEntity(this) != null) {
             BlockEntity blockEntity = this.level.getBlockEntity(this);
             MainLogger.getLogger().warning("Found unused BlockEntity at world=" + blockEntity.getLevel().getName() + " x=" + blockEntity.getX() + " y=" + blockEntity.getY() + " z=" + blockEntity.getZ() + " whilst attempting to place piston, closing it.");
@@ -145,7 +145,13 @@ public abstract class BlockPistonBase extends BlockSolidMeta implements Faceable
                 return 0;
             }
 
-            BlockEntityPistonArm arm = getOrCreateBlockEntity();
+            // We can't use getOrCreateBlockEntity(), because the update method is called on block place,
+            // before the "real" BlockEntity is set. That means, if we'd use the other method here,
+            // it would create two BlockEntities.
+            BlockEntityPistonArm arm = this.getBlockEntity();
+            if (arm == null)
+                return 0;
+
             boolean powered = this.isPowered();
 
             if (arm.state % 2 == 0 && arm.powered != powered && checkState(powered)) {

--- a/src/main/java/cn/nukkit/block/BlockPistonHead.java
+++ b/src/main/java/cn/nukkit/block/BlockPistonHead.java
@@ -48,10 +48,13 @@ public class BlockPistonHead extends BlockTransparentMeta implements Faceable {
     @Override
     public boolean onBreak(Item item) {
         this.level.setBlock(this, Block.get(BlockID.AIR), true, true);
-        Block piston = getSide(getBlockFace().getOpposite());
+        Block side = getSide(getBlockFace().getOpposite());
 
-        if (piston instanceof BlockPistonBase && ((BlockPistonBase) piston).getBlockFace() == this.getBlockFace()) {
+        if (side instanceof BlockPistonBase && ((BlockPistonBase) side).getBlockFace() == this.getBlockFace()) {
+            BlockPistonBase piston = (BlockPistonBase) side;
             piston.onBreak(item);
+
+            if(piston.getBlockEntity() != null) piston.getBlockEntity().close();
         }
         return true;
     }

--- a/src/main/java/cn/nukkit/block/BlockRedstoneComparator.java
+++ b/src/main/java/cn/nukkit/block/BlockRedstoneComparator.java
@@ -157,7 +157,12 @@ public abstract class BlockRedstoneComparator extends BlockRedstoneDiode impleme
         }
 
         int output = this.calculateOutput();
-        BlockEntityComparator blockEntityComparator = getOrCreateBlockEntity();
+        // We can't use getOrCreateBlockEntity(), because the update method is called on block place,
+        // before the "real" BlockEntity is set. That means, if we'd use the other method here,
+        // it would create two BlockEntities.
+        BlockEntityComparator blockEntityComparator = getBlockEntity();
+        if (blockEntityComparator == null)
+            return;
 
         int currentOutput = blockEntityComparator.getOutputSignal();
         blockEntityComparator.setOutputSignal(output);


### PR DESCRIPTION
This pullrequest fixes, that the blockentities of some blocks were create twice, because the `onUpdate()` method created an entity with `#getOrCreateBlockEntity()` and the `#setBlockAndCreateEntity()` first sets the block with update and then creates the blockentity.

The pr also makes, if you break a piston on the arm, the blockentity of the piston now will get removed.

This also fixes #727

If you placed some pistons before this PR, you have to repeat the follwing, until the "Removed unused blockentity" message disappears:
1. Destroy the piston.
2. Go to other world (or restart the server)
3. Unload the level with the broken piston (not necessary if you restarted the server)
4. Load it again and go to the world
5. place piston