### PR TITLE
Allow anvil items to be renamed

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3769,6 +3769,14 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     notFound.setTrackingId(posTrackReq.getTrackingId());
                     dataPacket(notFound);
                     break;
+                case ProtocolInfo.FILTER_TEXT_PACKET:
+                    FilterTextPacket filterTextPacket = (FilterTextPacket) packet;
+
+                    FilterTextPacket textResponsePacket = new FilterTextPacket();
+                    textResponsePacket.text = filterTextPacket.text;
+                    textResponsePacket.fromServer = true;
+                    this.dataPacket(textResponsePacket);
+                    break;
                 default:
                     break;
             }

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3772,8 +3772,13 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 case ProtocolInfo.FILTER_TEXT_PACKET:
                     FilterTextPacket filterTextPacket = (FilterTextPacket) packet;
 
+                    PlayerRenameItemEvent renameItemEvent = new PlayerRenameItemEvent(this, filterTextPacket.text);
+                    this.server.getPluginManager().callEvent(renameItemEvent);
+                    if (renameItemEvent.isCancelled()) {
+                        break;
+                    }
                     FilterTextPacket textResponsePacket = new FilterTextPacket();
-                    textResponsePacket.text = filterTextPacket.text;
+                    textResponsePacket.text = renameItemEvent.getAdjustedText();
                     textResponsePacket.fromServer = true;
                     this.dataPacket(textResponsePacket);
                     break;

--- a/src/main/java/cn/nukkit/event/player/PlayerRenameItemEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerRenameItemEvent.java
@@ -1,0 +1,35 @@
+package cn.nukkit.event.player;
+
+import cn.nukkit.Player;
+import cn.nukkit.event.Cancellable;
+import cn.nukkit.event.HandlerList;
+
+public class PlayerRenameItemEvent extends PlayerEvent implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlers() {
+        return handlers;
+    }
+
+    private final String playerSubmittedText;
+    private String adjustedText;
+
+    public PlayerRenameItemEvent(Player player, String text) {
+        this.player = player;
+        this.playerSubmittedText = text;
+        this.adjustedText = text;
+    }
+
+    public String getPlayerSubmittedText() {
+        return playerSubmittedText;
+    }
+
+    public String getAdjustedText() {
+        return adjustedText;
+    }
+
+    public void setAdjustedText(String adjustedText) {
+        this.adjustedText = adjustedText;
+    }
+}

--- a/src/main/java/cn/nukkit/network/Network.java
+++ b/src/main/java/cn/nukkit/network/Network.java
@@ -471,5 +471,6 @@ public class Network {
         this.registerPacket(ProtocolInfo.POS_TRACKING_CLIENT_REQUEST_PACKET, PositionTrackingDBClientRequestPacket.class);
         this.registerPacket(ProtocolInfo.POS_TRACKING_SERVER_BROADCAST_PACKET, PositionTrackingDBServerBroadcastPacket.class);
         this.registerPacket(ProtocolInfo.UPDATE_PLAYER_GAME_TYPE_PACKET, UpdatePlayerGameTypePacket.class);
+        this.registerPacket(ProtocolInfo.FILTER_TEXT_PACKET, FilterTextPacket.class);
     }
 }

--- a/src/main/java/cn/nukkit/network/protocol/FilterTextPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/FilterTextPacket.java
@@ -1,0 +1,32 @@
+package cn.nukkit.network.protocol;
+
+import cn.nukkit.api.Since;
+import lombok.ToString;
+
+@Since("1.4.0.0-PN")
+@ToString
+public class FilterTextPacket extends DataPacket {
+
+    public static final byte NETWORK_ID = ProtocolInfo.FILTER_TEXT_PACKET;
+
+    @Since("1.4.0.0-PN") public String text;
+    @Since("1.4.0.0-PN") public boolean fromServer;
+
+    @Override
+    public byte pid() {
+        return NETWORK_ID;
+    }
+
+    @Override
+    public void decode() {
+        this.text = this.getString();
+        this.fromServer = this.getBoolean();
+    }
+
+    @Override
+    public void encode() {
+        this.reset();
+        this.putString(this.text);
+        this.putBoolean(this.fromServer);
+    }
+}

--- a/src/main/java/cn/nukkit/network/protocol/ProtocolInfo.java
+++ b/src/main/java/cn/nukkit/network/protocol/ProtocolInfo.java
@@ -178,7 +178,7 @@ public interface ProtocolInfo {
     @Since("1.3.2.0-PN") byte PLAYER_FOG_PACKET = (byte) 0xa0;
     @Since("1.3.2.0-PN") byte CORRECT_PLAYER_MOVE_PREDICTION_PACKET = (byte) 0xa1;
     @Since("1.3.2.0-PN") byte ITEM_COMPONENT_PACKET = (byte) 0xa2;
-    byte FILTER_TEXT_PACKET = (byte) 0xa3;
+    @Since("1.4.0.0-PN") byte FILTER_TEXT_PACKET = (byte) 0xa3;
 
     byte BATCH_PACKET = (byte) 0xff;
 }


### PR DESCRIPTION
This commit allows the client to recognize that items can be renamed.

I also added an event that utilizes the new FilterTextPacket, allowing plugins to choose what the final output of a renamed item should be. Cancelling the event leaves the item as the last accepted rename, or, if all events are cancelled, you can effectively disable renaming. 