### PR TITLE
Fix the path block won't decay to dirt when you place a solid block above it (Fix #904)

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockGrass.java
+++ b/src/main/java/cn/nukkit/block/BlockGrass.java
@@ -60,7 +60,7 @@ public class BlockGrass extends BlockDirt {
 
     @Override
     public double getResistance() {
-        return 3;
+        return 0.6;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockGrassPath.java
+++ b/src/main/java/cn/nukkit/block/BlockGrassPath.java
@@ -41,10 +41,15 @@ public class BlockGrassPath extends BlockGrass {
     public double getMaxY() {
         return this.y + 1;
     }
+    
+    @Override
+    public double getHardness() {
+        return 0.65;
+    }
 
     @Override
     public double getResistance() {
-        return 3.25;
+        return 0.65;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockGrassPath.java
+++ b/src/main/java/cn/nukkit/block/BlockGrassPath.java
@@ -64,12 +64,12 @@ public class BlockGrassPath extends BlockGrass {
 
     @Override
     public int onUpdate(int type) {
-        if (type == Level.BLOCK_UPDATE_RANDOM) {
+        if (type == Level.BLOCK_UPDATE_NORMAL) {
             if (this.up().isSolid()) {
                 this.level.setBlock(this, Block.get(BlockID.DIRT), false, true);
             }
             
-            return Level.BLOCK_UPDATE_RANDOM;
+            return Level.BLOCK_UPDATE_NORMAL;
         }
         return 0;
     }

--- a/src/main/java/cn/nukkit/block/BlockGrassPath.java
+++ b/src/main/java/cn/nukkit/block/BlockGrassPath.java
@@ -6,6 +6,7 @@ import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemTool;
+import cn.nukkit.level.Level;
 import cn.nukkit.level.Sound;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.utils.BlockColor;
@@ -16,7 +17,6 @@ import javax.annotation.Nonnull;
  * @author xtypr
  * @since 2015/11/22
  */
-
 public class BlockGrassPath extends BlockGrass {
 
     public BlockGrassPath() {
@@ -59,6 +59,13 @@ public class BlockGrassPath extends BlockGrass {
 
     @Override
     public int onUpdate(int type) {
+        if (type == Level.BLOCK_UPDATE_RANDOM) {
+            if (this.up().isSolid()) {
+                this.level.setBlock(this, Block.get(BlockID.DIRT), false, true);
+            }
+            
+            return Level.BLOCK_UPDATE_RANDOM;
+        }
         return 0;
     }
 


### PR DESCRIPTION
Fix the path block won't decay to dirt when you place a solid block above it (Fix #904)

Dirt Path:
  - Fix the path block won't decay to dirt when you place a solid block above it
  - Fix hardness and resistance

Grass Block:
  - Fix resistance