### PR TITLE
Poisoning fix

### DIFF
--- a/src/main/java/cn/nukkit/potion/Effect.java
+++ b/src/main/java/cn/nukkit/potion/Effect.java
@@ -209,7 +209,7 @@ public class Effect implements Cloneable {
     public void applyEffect(Entity entity) {
         switch (this.id) {
             case Effect.POISON: //POISON
-                if (entity.getHealth() > 1) {
+                if (entity.getHealth() > 1.5) {
                     entity.attack(new EntityDamageEvent(entity, DamageCause.MAGIC, 1));
                 }
                 break;


### PR DESCRIPTION
I noticed that if you impose the effect of poisoning on yourself in any way, then it does not leave 0.5 HP, but immediately kills.