### PR TITLE
Bumping to 431 protocol (1.16.220)

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3823,7 +3823,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             success = ((ItemBookAndQuill) newBook).swapPages(bookEditPacket.pageNumber, bookEditPacket.secondaryPageNumber);
                             break;
                         case SIGN_BOOK:
-                            newBook = Item.get(Item.WRITTEN_BOOK, 0, 1, oldBook.getCompoundTag());
+                            newBook = Item.get(Item.WRITTEN_BOOK, 0, 1, oldBook.getCompoundTag(), 0);
                             success = ((ItemBookWritten) newBook).signBook(bookEditPacket.title, bookEditPacket.author, bookEditPacket.xuid, ItemBookWritten.GENERATION_ORIGINAL);
                             break;
                         default:

--- a/src/main/java/cn/nukkit/blockstate/BlockStateRegistry.java
+++ b/src/main/java/cn/nukkit/blockstate/BlockStateRegistry.java
@@ -230,7 +230,7 @@ public class BlockStateRegistry {
      * @return {@code null} if the runtime id does not matches any known block state.
      */
     @Nullable
-    public BlockState getBlockStateByRuntimeId(int runtimeId) {
+    public static BlockState getBlockStateByRuntimeId(int runtimeId) {
         Registration registration = findRegistrationByRuntimeId(runtimeId);
         if (registration == null) {
             return null;

--- a/src/main/java/cn/nukkit/command/defaults/EnchantCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/EnchantCommand.java
@@ -78,7 +78,7 @@ public class EnchantCommand extends VanillaCommand {
             item.addEnchantment(enchantment);
             player.getInventory().setItemInHand(item);
         } else {
-            Item enchanted = Item.get(ItemID.ENCHANTED_BOOK, 0, 1, item.getCompoundTag());
+            Item enchanted = Item.get(ItemID.ENCHANTED_BOOK, 0, 1, item.getCompoundTag(), 0);
             enchanted.addEnchantment(enchantment);
             Item clone = item.clone();
             clone.count--;

--- a/src/main/java/cn/nukkit/item/ItemSpawnEgg.java
+++ b/src/main/java/cn/nukkit/item/ItemSpawnEgg.java
@@ -96,7 +96,7 @@ public class ItemSpawnEgg extends Item {
     @Since("1.3.2.0-PN")
     @PowerNukkitOnly
     public Item getLegacySpawnEgg() {
-        return Item.get(SPAWN_EGG, getEntityNetworkId(), getCount(), getCompoundTag());
+        return Item.get(SPAWN_EGG, getEntityNetworkId(), getCount(), getCompoundTag(), 0);
     }
 
     @PowerNukkitOnly

--- a/src/main/java/cn/nukkit/item/MinecraftItemID.java
+++ b/src/main/java/cn/nukkit/item/MinecraftItemID.java
@@ -1035,6 +1035,12 @@ public enum MinecraftItemID {
     }
 
     @PowerNukkitOnly
+    @Since("1.4.0.0-PN")
+    public Item get(int amount, int blockRuntimeId) {
+        return RuntimeItems.getRuntimeMapping().getItemByNamespaceId(getItemFormNamespaceId(), amount, blockRuntimeId);
+    }
+
+    @PowerNukkitOnly
     @Since("1.3.2.0-PN")
     public Item get(int amount, byte[] compoundTag) {
         Item item = get(amount);

--- a/src/main/java/cn/nukkit/item/RuntimeItemMapping.java
+++ b/src/main/java/cn/nukkit/item/RuntimeItemMapping.java
@@ -3,6 +3,7 @@ package cn.nukkit.item;
 import cn.nukkit.api.API;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
+import io.netty.util.internal.EmptyArrays;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
@@ -132,23 +133,29 @@ public class RuntimeItemMapping {
      * Creates a new instance of the respective {@link Item} by the <b>namespaced id</b>.
      * @param namespaceId The namespaced id
      * @param amount How many items will be in the stack.
+     * @param runtimeBlockId The block runtime id.
      * @return The correct {@link Item} instance with the write <b>item id</b> and <b>item damage</b> values.
      * @throws IllegalArgumentException If there are unknown mappings in the process. 
      */
     @PowerNukkitOnly
-    @Since("1.3.2.0-PN")
+    @Since("1.4.0.0-PN")
     @Nonnull
-    public Item getItemByNamespaceId(@Nonnull String namespaceId, int amount) {
+    public Item getItemByNamespaceId(@Nonnull String namespaceId, int amount, int runtimeBlockId) {
         int legacyFullId = getLegacyFullId(
                 getNetworkIdByNamespaceId(namespaceId)
                         .orElseThrow(()-> new IllegalArgumentException("The network id of \""+namespaceId+"\" is unknown"))
         );
         if (RuntimeItems.hasData(legacyFullId)) {
-            return Item.get(RuntimeItems.getId(legacyFullId), RuntimeItems.getData(legacyFullId), amount);
+            return Item.get(RuntimeItems.getId(legacyFullId), RuntimeItems.getData(legacyFullId), amount, EmptyArrays.EMPTY_BYTES, runtimeBlockId);
         } else {
-            Item item = Item.get(RuntimeItems.getId(legacyFullId));
-            item.setCount(amount);
+            Item item = Item.get(RuntimeItems.getId(legacyFullId), 0, amount, EmptyArrays.EMPTY_BYTES, runtimeBlockId);
             return item;
         }
+    }
+
+    @PowerNukkitOnly
+    @Since("1.3.2.0-PN")
+    public Item getItemByNamespaceId(@Nonnull String namespaceId, int amount) {
+        return this.getItemByNamespaceId(namespaceId, amount, 0);
     }
 }

--- a/src/main/java/cn/nukkit/network/LittleEndianByteBufInputStream.java
+++ b/src/main/java/cn/nukkit/network/LittleEndianByteBufInputStream.java
@@ -1,0 +1,51 @@
+package cn.nukkit.network;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+
+import java.io.IOException;
+
+public class LittleEndianByteBufInputStream extends ByteBufInputStream {
+
+    private final ByteBuf buffer;
+
+    public LittleEndianByteBufInputStream(ByteBuf buffer) {
+        super(buffer);
+        this.buffer = buffer;
+    }
+
+    @Override
+    public char readChar() throws IOException {
+        return Character.reverseBytes(buffer.readChar());
+    }
+
+    @Override
+    public double readDouble() throws IOException {
+        return buffer.readDoubleLE();
+    }
+
+    @Override
+    public float readFloat() throws IOException {
+        return buffer.readFloatLE();
+    }
+
+    @Override
+    public short readShort() throws IOException {
+        return buffer.readShortLE();
+    }
+
+    @Override
+    public int readUnsignedShort() throws IOException {
+        return buffer.readUnsignedShortLE();
+    }
+
+    @Override
+    public long readLong() throws IOException {
+        return buffer.readLongLE();
+    }
+
+    @Override
+    public int readInt() throws IOException {
+        return buffer.readIntLE();
+    }
+}

--- a/src/main/java/cn/nukkit/network/LittleEndianByteBufOutputStream.java
+++ b/src/main/java/cn/nukkit/network/LittleEndianByteBufOutputStream.java
@@ -1,0 +1,54 @@
+package cn.nukkit.network;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufOutputStream;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class LittleEndianByteBufOutputStream extends ByteBufOutputStream {
+
+    private final ByteBuf buffer;
+
+    public LittleEndianByteBufOutputStream(ByteBuf buffer) {
+        super(buffer);
+        this.buffer = buffer;
+    }
+
+    @Override
+    public void writeChar(int v) throws IOException {
+        this.buffer.writeChar(Character.reverseBytes((char) v));
+    }
+
+    @Override
+    public void writeDouble(double v) throws IOException {
+        this.buffer.writeDoubleLE(v);
+    }
+
+    @Override
+    public void writeFloat(float v) throws IOException {
+        this.buffer.writeFloatLE(v);
+    }
+
+    @Override
+    public void writeShort(int val) throws IOException {
+        this.buffer.writeShortLE(val);
+    }
+
+    @Override
+    public void writeLong(long val) throws IOException {
+        this.buffer.writeLongLE(val);
+    }
+
+    @Override
+    public void writeInt(int val) throws IOException {
+        this.buffer.writeIntLE(val);
+    }
+
+    @Override
+    public void writeUTF(String string) throws IOException {
+        byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
+        this.writeShort(bytes.length);
+        this.write(bytes);
+    }
+}

--- a/src/main/java/cn/nukkit/network/protocol/CraftingDataPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/CraftingDataPacket.java
@@ -27,8 +27,8 @@ public class CraftingDataPacket extends DataPacket {
     public static final String CRAFTING_TAG_SMOKER = "smoker";
 
     private List<Recipe> entries = new ArrayList<>();
-    private List<BrewingRecipe> brewingEntries = new ArrayList<>();
-    private List<ContainerRecipe> containerEntries = new ArrayList<>();
+    private final List<BrewingRecipe> brewingEntries = new ArrayList<>();
+    private final List<ContainerRecipe> containerEntries = new ArrayList<>();
     public boolean cleanRecipes;
 
     public void addShapelessRecipe(ShapelessRecipe... recipe) {
@@ -103,7 +103,7 @@ public class CraftingDataPacket extends DataPacket {
                     this.putUnsignedVarInt(1);
                     this.putRecipeIngredient(stonecutter.getIngredient());
                     this.putUnsignedVarInt(1);
-                    this.putSlot(stonecutter.getResult());
+                    this.putSlotInstance(stonecutter.getResult());
                     this.putUUID(stonecutter.getId());
                     this.putString(CRAFTING_TAG_STONECUTTER);
                     this.putVarInt(stonecutter.getPriority());
@@ -119,7 +119,7 @@ public class CraftingDataPacket extends DataPacket {
                         this.putRecipeIngredient(ingredient);
                     }
                     this.putUnsignedVarInt(1);
-                    this.putSlot(shapeless.getResult());
+                    this.putSlotInstance(shapeless.getResult());
                     this.putUUID(shapeless.getId());
                     this.putString(recipe.getType() == RecipeType.CARTOGRAPHY ? CRAFTING_TAG_CARTOGRAPHY_TABLE : CRAFTING_TAG_CRAFTING_TABLE);
                     this.putVarInt(shapeless.getPriority());
@@ -141,7 +141,7 @@ public class CraftingDataPacket extends DataPacket {
                     outputs.addAll(shaped.getExtraResults());
                     this.putUnsignedVarInt(outputs.size());
                     for (Item output : outputs) {
-                        this.putSlot(output);
+                        this.putSlotInstance(output);
                     }
                     this.putUUID(shaped.getId());
                     this.putString(CRAFTING_TAG_CRAFTING_TABLE);
@@ -162,7 +162,7 @@ public class CraftingDataPacket extends DataPacket {
                     if (recipe.getType().name().endsWith("_DATA")) {
                         this.putVarInt(input.getDamage());
                     }
-                    this.putSlot(smelting.getResult());
+                    this.putSlotInstance(smelting.getResult());
                     switch (recipe.getType()) {
                         case FURNACE:
                         case FURNACE_DATA:

--- a/src/main/java/cn/nukkit/network/protocol/CreativeContentPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/CreativeContentPacket.java
@@ -26,9 +26,8 @@ public class CreativeContentPacket extends DataPacket {
         this.reset();
         this.putUnsignedVarInt(entries.length);
         for (int i = 0; i < entries.length; i++) {
-            this.putUnsignedVarInt(i + 1);
-            this.putSlot(entries[i]);
+            this.putVarInt(i + 1);
+            this.putSlotInstance(entries[i]);
         }
-
     }
 }

--- a/src/main/java/cn/nukkit/network/protocol/InventoryContentPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/InventoryContentPacket.java
@@ -42,7 +42,6 @@ public class InventoryContentPacket extends DataPacket {
         this.putUnsignedVarInt(this.inventoryId);
         this.putUnsignedVarInt(this.slots.length);
         for (Item slot : this.slots) {
-            this.putVarInt(slot.getId());
             this.putSlot(slot);
         }
     }

--- a/src/main/java/cn/nukkit/network/protocol/InventorySlotPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/InventorySlotPacket.java
@@ -31,7 +31,6 @@ public class InventorySlotPacket extends DataPacket {
         this.reset();
         this.putUnsignedVarInt(this.inventoryId);
         this.putUnsignedVarInt(this.slot);
-        this.putVarInt(this.item.getId());
         this.putSlot(this.item);
     }
 }

--- a/src/main/java/cn/nukkit/network/protocol/InventoryTransactionPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/InventoryTransactionPacket.java
@@ -40,7 +40,7 @@ public class InventoryTransactionPacket extends DataPacket {
     public int transactionType;
     public NetworkInventoryAction[] actions;
     public TransactionData transactionData;
-    @Since("1.3.0.0-PN") public boolean hasNetworkIds;
+    @Since("1.3.0.0-PN") public boolean hasNetworkIds = false;
     @Since("1.3.0.0-PN") public int legacyRequestId;
 
     /**
@@ -62,7 +62,6 @@ public class InventoryTransactionPacket extends DataPacket {
         this.putVarInt(this.legacyRequestId);
         //TODO legacySlot array
         this.putUnsignedVarInt(this.transactionType);
-        this.putBoolean(this.hasNetworkIds);
         this.putUnsignedVarInt(this.actions.length);
         for (NetworkInventoryAction action : this.actions) {
             action.write(this);
@@ -121,8 +120,6 @@ public class InventoryTransactionPacket extends DataPacket {
         }
 
         this.transactionType = (int) this.getUnsignedVarInt();
-
-        this.hasNetworkIds = this.getBoolean();
 
         int length = (int) this.getUnsignedVarInt();
         Collection<NetworkInventoryAction> actions = new ArrayDeque<>();

--- a/src/main/java/cn/nukkit/network/protocol/ProtocolInfo.java
+++ b/src/main/java/cn/nukkit/network/protocol/ProtocolInfo.java
@@ -15,12 +15,12 @@ public interface ProtocolInfo {
     /**
      * Actual Minecraft: PE protocol version
      */
-    int CURRENT_PROTOCOL = dynamic(428);
+    int CURRENT_PROTOCOL = dynamic(431);
 
     List<Integer> SUPPORTED_PROTOCOLS = Ints.asList(CURRENT_PROTOCOL);
 
-    String MINECRAFT_VERSION = dynamic("v1.16.210");
-    String MINECRAFT_VERSION_NETWORK = dynamic("1.16.210");
+    String MINECRAFT_VERSION = dynamic("v1.16.220");
+    String MINECRAFT_VERSION_NETWORK = dynamic("1.16.220");
 
     byte LOGIN_PACKET = 0x01;
     byte PLAY_STATUS_PACKET = 0x02;

--- a/src/main/java/cn/nukkit/network/protocol/types/NetworkInventoryAction.java
+++ b/src/main/java/cn/nukkit/network/protocol/types/NetworkInventoryAction.java
@@ -114,9 +114,6 @@ public class NetworkInventoryAction {
         this.oldItem = packet.getSlot();
         this.newItem = packet.getSlot();
 
-        if (packet.hasNetworkIds) {
-            this.stackNetworkId = packet.getVarInt();
-        }
         return this;
     }
 
@@ -139,10 +136,6 @@ public class NetworkInventoryAction {
         packet.putUnsignedVarInt(this.inventorySlot);
         packet.putSlot(this.oldItem);
         packet.putSlot(this.newItem);
-
-        if (packet.hasNetworkIds) {
-            packet.putVarInt(this.stackNetworkId);
-        }
     }
 
     public InventoryAction createInventoryAction(Player player) {

--- a/src/main/java/cn/nukkit/utils/BinaryStream.java
+++ b/src/main/java/cn/nukkit/utils/BinaryStream.java
@@ -1,9 +1,9 @@
 package cn.nukkit.utils;
 
+import cn.nukkit.blockstate.BlockStateRegistry;
 import cn.nukkit.entity.Attribute;
 import cn.nukkit.entity.data.Skin;
 import cn.nukkit.item.Item;
-import cn.nukkit.item.ItemDurable;
 import cn.nukkit.item.ItemID;
 import cn.nukkit.item.RuntimeItems;
 import cn.nukkit.level.GameRule;
@@ -15,9 +15,13 @@ import cn.nukkit.nbt.NBTIO;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.nbt.tag.ListTag;
 import cn.nukkit.nbt.tag.StringTag;
+import cn.nukkit.network.LittleEndianByteBufInputStream;
+import cn.nukkit.network.LittleEndianByteBufOutputStream;
 import cn.nukkit.network.protocol.types.EntityLink;
+import io.netty.buffer.AbstractByteBufAllocator;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.internal.EmptyArrays;
-import it.unimi.dsi.fastutil.io.FastByteArrayInputStream;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -372,158 +376,178 @@ public class BinaryStream {
     }
 
     public Item getSlot() {
-        int networkId = this.getVarInt();
-        if (networkId == 0) {
+        int id = getVarInt();
+        if (id == 0) {
             return Item.get(0, 0, 0);
         }
 
-        int legacyFullId = RuntimeItems.getRuntimeMapping().getLegacyFullId(networkId);
-        int id = RuntimeItems.getId(legacyFullId);
-        boolean hasData = RuntimeItems.hasData(legacyFullId);
+        int count = getLShort();
+        int damage = (int) getUnsignedVarInt();
 
-        int auxValue = this.getVarInt();
-        int data = auxValue >> 8;
+        int fullId = RuntimeItems.getRuntimeMapping().getLegacyFullId(id);
+        boolean hasData = RuntimeItems.hasData(fullId);
+        id = RuntimeItems.getId(fullId);
+
         if (hasData) {
-            // Swap data using legacy full id
-            data = RuntimeItems.getData(legacyFullId);
-        } else if (data == Short.MAX_VALUE) {
-            data = -1;
+            damage = RuntimeItems.getData(fullId);
         }
-        int cnt = auxValue & 0xff;
 
-        int nbtLen = this.getLShort();
-        byte[] nbt = EmptyArrays.EMPTY_BYTES;
-        if (nbtLen < Short.MAX_VALUE) {
-            nbt = this.get(nbtLen);
-        } else if (nbtLen == 65535) {
-            int nbtTagCount = (int) getUnsignedVarInt();
-            int offset = getOffset();
-            FastByteArrayInputStream stream = new FastByteArrayInputStream(get());
-            for (int i = 0; i < nbtTagCount; i++) {
-                try {
-                    // TODO: 05/02/2019 This hack is necessary because we keep the raw NBT tag. Try to remove it.
-                    CompoundTag tag = NBTIO.read(stream, ByteOrder.LITTLE_ENDIAN, true);
-                    // tool damage hack
-                    if (tag.contains("Damage")) {
-                        data = tag.getInt("Damage");
-                        tag.remove("Damage");
-                    }
-                    if (tag.contains("__DamageConflict__")) {
-                        tag.put("Damage", tag.removeAndGet("__DamageConflict__"));
-                    }
-                    if (!tag.getAllTags().isEmpty()) {
-                        nbt = NBTIO.write(tag, ByteOrder.LITTLE_ENDIAN, false);
-                    }
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
+        if (getBoolean()) { // hasNetId
+            getVarInt(); // netId
+        }
+
+        getVarInt(); // blockRuntimeId
+
+        byte[] bytes = getByteArray();
+        ByteBuf buf = AbstractByteBufAllocator.DEFAULT.ioBuffer(bytes.length);
+        buf.writeBytes(bytes);
+
+        byte[] nbt = new byte[0];
+        String[] canPlace;
+        String[] canBreak;
+
+        try (LittleEndianByteBufInputStream stream = new LittleEndianByteBufInputStream(buf)) {
+            int nbtSize = stream.readShort();
+
+            CompoundTag compoundTag = null;
+            if (nbtSize > 0) {
+                compoundTag = NBTIO.read(stream, ByteOrder.LITTLE_ENDIAN);
+            } else if (nbtSize == -1) {
+                int tagCount = stream.readUnsignedByte();
+                if (tagCount != 1) throw new IllegalArgumentException("Expected 1 tag but got " + tagCount);
+                compoundTag = NBTIO.read(stream, ByteOrder.LITTLE_ENDIAN);
             }
-            setOffset(offset + (int) stream.position());
+
+            if (compoundTag != null && compoundTag.getAllTags().size() > 0) {
+                nbt = NBTIO.write(compoundTag, ByteOrder.LITTLE_ENDIAN, false);
+            }
+
+            canPlace = new String[stream.readInt()];
+            for (int i = 0; i < canPlace.length; i++) {
+                canPlace[i] = stream.readUTF();
+            }
+
+            canBreak = new String[stream.readInt()];
+            for (int i = 0; i < canBreak.length; i++) {
+                canBreak[i] = stream.readUTF();
+            }
+
+            if (id == ItemID.SHIELD) {
+                stream.readLong();
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to read item user data", e);
+        } finally {
+            buf.release();
         }
 
-        String[] canPlaceOn = new String[this.getVarInt()];
-        for (int i = 0; i < canPlaceOn.length; ++i) {
-            canPlaceOn[i] = this.getString();
-        }
+        Item item = Item.get(id, damage, count, nbt);
 
-        String[] canDestroy = new String[this.getVarInt()];
-        for (int i = 0; i < canDestroy.length; ++i) {
-            canDestroy[i] = this.getString();
-        }
-
-        Item item = Item.get(
-                id, data, cnt, nbt
-        );
-
-        if (canDestroy.length > 0 || canPlaceOn.length > 0) {
+        if (canBreak.length > 0 || canPlace.length > 0) {
             CompoundTag namedTag = item.getNamedTag();
             if (namedTag == null) {
                 namedTag = new CompoundTag();
             }
 
-            if (canDestroy.length > 0) {
+            if (canBreak.length > 0) {
                 ListTag<StringTag> listTag = new ListTag<>("CanDestroy");
-                for (String blockName : canDestroy) {
+                for (String blockName : canBreak) {
                     listTag.add(new StringTag("", blockName));
                 }
                 namedTag.put("CanDestroy", listTag);
             }
 
-            if (canPlaceOn.length > 0) {
+            if (canPlace.length > 0) {
                 ListTag<StringTag> listTag = new ListTag<>("CanPlaceOn");
-                for (String blockName : canPlaceOn) {
+                for (String blockName : canPlace) {
                     listTag.add(new StringTag("", blockName));
                 }
                 namedTag.put("CanPlaceOn", listTag);
             }
-            item.setNamedTag(namedTag);
-        }
 
-        if (item.getId() == 513) { // TODO: Shields
-            this.getVarLong();
+            item.setNamedTag(namedTag);
         }
 
         return item;
     }
 
-    public void putSlot(Item item) {
+    public void putSlotInstance(Item item) {
         if (item == null || item.getId() == 0) {
-            this.putVarInt(0);
+            this.putByte((byte) 0);
             return;
         }
 
         int networkFullId = RuntimeItems.getRuntimeMapping().getNetworkFullId(item);
         int networkId = RuntimeItems.getNetworkId(networkFullId);
-        boolean clearData = RuntimeItems.hasData(networkFullId);
+
+        int blockRuntimeId = BlockStateRegistry.getRuntimeId(item.getBlock().getCurrentState());
+
         this.putVarInt(networkId);
 
-        int auxValue = item.getCount();
-        boolean isDurable = item instanceof ItemDurable;
-        //if (!isDurable) {
-            int meta = clearData ? 0 : item.hasMeta() ? item.getDamage() : -1;
-            auxValue |= ((meta & 0x7fff) << 8);
-        //}
-        this.putVarInt(auxValue);
+        this.putLShort(item.getCount());
+        this.putUnsignedVarInt(item.getDamage());
+        writeCompoundTag(item, blockRuntimeId);
 
-        if (item.hasCompoundTag() || isDurable && item.getDamage() != 0) {
-            try {
-                // hack for tool damage
-                byte[] nbt = item.getCompoundTag();
-                CompoundTag tag;
-                if (nbt == null || nbt.length == 0) {
-                    tag = new CompoundTag();
-                } else {
-                    tag = NBTIO.read(nbt, ByteOrder.LITTLE_ENDIAN, false);
-                }
-                if (tag.contains("Damage")) {
-                    tag.put("__DamageConflict__", tag.removeAndGet("Damage"));
-                }
-                if (isDurable) {
-                    tag.putInt("Damage", item.getDamage());
-                }
+    }
 
-                this.putLShort(0xffff);
-                this.putByte((byte) 1);
-                this.put(NBTIO.write(tag, ByteOrder.LITTLE_ENDIAN, true));
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
+    public void putSlot(Item item) {
+
+        if (item == null || item.getId() == 0) {
+            this.putByte((byte) 0);
+            return;
+        }
+
+        int networkFullId = RuntimeItems.getRuntimeMapping().getNetworkFullId(item);
+        int networkId = RuntimeItems.getNetworkId(networkFullId);
+
+        int blockRuntimeId = BlockStateRegistry.getRuntimeId(item.getBlock().getCurrentState());
+
+        this.putVarInt(networkId);
+
+        this.putLShort(item.getCount());
+        this.putUnsignedVarInt(item.getDamage());
+        this.putBoolean(true);
+        this.putVarInt(0);
+        writeCompoundTag(item, blockRuntimeId);
+
+    }
+
+    private void writeCompoundTag(Item item, int blockRuntimeId) {
+        this.putVarInt(Math.max(blockRuntimeId, 0));
+
+        ByteBuf buf = ByteBufAllocator.DEFAULT.ioBuffer();
+        try (LittleEndianByteBufOutputStream stream = new LittleEndianByteBufOutputStream(buf)) {
+            if (item.hasCompoundTag()) {
+                stream.writeShort(-1);
+                stream.writeByte(1);
+                stream.write(item.getCompoundTag());
+            } else {
+                buf.writeShortLE(0);
             }
-        } else {
-            this.putLShort(0);
-        }
-        List<String> canPlaceOn = extractStringList(item, "CanPlaceOn");
-        List<String> canDestroy = extractStringList(item, "CanDestroy");
-        this.putVarInt(canPlaceOn.size());
-        for (String block : canPlaceOn) {
-            this.putString(block);
-        }
-        this.putVarInt(canDestroy.size());
-        for (String block : canDestroy) {
-            this.putString(block);
-        }
+            List<String> canPlaceOn = extractStringList(item, "CanPlaceOn");
+            stream.writeInt(canPlaceOn.size());
+            for (String string : canPlaceOn) {
+                stream.writeUTF(string);
+            }
 
-        if (item.getId() == ItemID.SHIELD) { // TODO: Shields
-            this.putVarLong(0);
+            List<String> canDestroy = extractStringList(item, "CanDestroy");
+            stream.writeInt(canDestroy.size());
+            for (String string : canDestroy) {
+                stream.writeUTF(string);
+            }
+
+            if (item.getId() == ItemID.SHIELD) {
+                stream.writeLong(0);
+            }
+
+            byte[] bytes = new byte[buf.readableBytes()];
+            buf.readBytes(bytes);
+            this.putByteArray(bytes);
+
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } finally {
+            buf.release();
         }
     }
 

--- a/src/main/java/cn/nukkit/utils/BinaryStream.java
+++ b/src/main/java/cn/nukkit/utils/BinaryStream.java
@@ -419,7 +419,16 @@ public class BinaryStream {
             }
 
             if (compoundTag != null && compoundTag.getAllTags().size() > 0) {
-                nbt = NBTIO.write(compoundTag, ByteOrder.LITTLE_ENDIAN, false);
+                if (compoundTag.contains("Damage")) {
+                    damage = compoundTag.getInt("Damage");
+                    compoundTag.remove("Damage");
+                }
+                if (compoundTag.contains("__DamageConflict__")) {
+                    compoundTag.put("Damage", compoundTag.removeAndGet("__DamageConflict__"));
+                }
+                if (!compoundTag.isEmpty()) {
+                    nbt = NBTIO.write(compoundTag, ByteOrder.LITTLE_ENDIAN);
+                }
             }
 
             canPlace = new String[stream.readInt()];
@@ -517,9 +526,24 @@ public class BinaryStream {
 
         ByteBuf buf = ByteBufAllocator.DEFAULT.ioBuffer();
         try (LittleEndianByteBufOutputStream stream = new LittleEndianByteBufOutputStream(buf)) {
-            if (item.hasCompoundTag()) {
+            if (item.getDamage() != 0) {
+                byte[] nbt = item.getCompoundTag();
+                CompoundTag tag;
+                if (nbt == null || nbt.length == 0) {
+                    tag = new CompoundTag();
+                } else {
+                    tag = NBTIO.read(nbt, ByteOrder.LITTLE_ENDIAN);
+                }
+                if (tag.contains("Damage")) {
+                    tag.put("__DamageConflict__", tag.removeAndGet("Damage"));
+                }
+                tag.putInt("Damage", item.getDamage());
                 stream.writeShort(-1);
-                stream.writeByte(1);
+                stream.writeByte(1); // Hardcoded in current version
+                stream.write(NBTIO.write(tag, ByteOrder.LITTLE_ENDIAN));
+            } else if (item.hasCompoundTag()) {
+                stream.writeShort(-1);
+                stream.writeByte(1); // Hardcoded in current version
                 stream.write(item.getCompoundTag());
             } else {
                 buf.writeShortLE(0);

--- a/src/main/resources/creativeitems.json
+++ b/src/main/resources/creativeitems.json
@@ -1646,52 +1646,68 @@
       "id" : "minecraft:wither_rose"
     },
     {
-      "id" : "minecraft:white_dye"
+      "id" : "minecraft:white_dye",
+      "damage": 19
     },
     {
-      "id" : "minecraft:light_gray_dye"
+      "id" : "minecraft:light_gray_dye",
+      "damage": 7
     },
     {
-      "id" : "minecraft:gray_dye"
+      "id" : "minecraft:gray_dye",
+      "damage": 8
     },
     {
-      "id" : "minecraft:black_dye"
+      "id" : "minecraft:black_dye",
+      "damage": 16
     },
     {
-      "id" : "minecraft:brown_dye"
+      "id" : "minecraft:brown_dye",
+      "damage": 17
     },
     {
-      "id" : "minecraft:red_dye"
+      "id" : "minecraft:red_dye",
+      "damage": 1
     },
     {
-      "id" : "minecraft:orange_dye"
+      "id" : "minecraft:orange_dye",
+      "damage": 14
     },
     {
-      "id" : "minecraft:yellow_dye"
+      "id" : "minecraft:yellow_dye",
+      "damage": 11
     },
     {
-      "id" : "minecraft:lime_dye"
+      "id" : "minecraft:lime_dye",
+      "damage": 10
     },
     {
-      "id" : "minecraft:green_dye"
+      "id" : "minecraft:green_dye",
+      "damage": 2
     },
     {
-      "id" : "minecraft:cyan_dye"
+      "id" : "minecraft:cyan_dye",
+      "damage": 6
     },
     {
-      "id" : "minecraft:light_blue_dye"
+      "id" : "minecraft:light_blue_dye",
+      "damage": 12
     },
     {
-      "id" : "minecraft:blue_dye"
+      "id" : "minecraft:blue_dye",
+      "damage": 18
     },
     {
-      "id" : "minecraft:purple_dye"
+      "id" : "minecraft:purple_dye",
+      "damage": 5
     },
     {
-      "id" : "minecraft:magenta_dye"
+      "id" : "minecraft:magenta_dye",
+      "damage": 13
     },
     {
-      "id" : "minecraft:pink_dye"
+      "id" : "minecraft:pink_dye",
+      "damage": 9
     },
     {
       "id" : "minecraft:ink_sac"
@@ -1700,10 +1716,12 @@
       "id" : "minecraft:cocoa_beans"
     },
     {
-      "id" : "minecraft:lapis_lazuli"
+      "id" : "minecraft:lapis_lazuli",
+      "damage": 4
     },
     {
-      "id" : "minecraft:bone_meal"
+      "id" : "minecraft:bone_meal",
+      "damage": 15
     },
     {
       "id" : "minecraft:vine"
@@ -1846,193 +1864,256 @@
       "id" : "minecraft:turtle_egg"
     },
     {
-      "id" : "minecraft:chicken_spawn_egg"
+      "id" : "minecraft:chicken_spawn_egg",
+      "damage": 10
     },
     {
-      "id" : "minecraft:bee_spawn_egg"
+      "id" : "minecraft:bee_spawn_egg",
+      "damage": 122
     },
     {
-      "id" : "minecraft:cow_spawn_egg"
+      "id" : "minecraft:cow_spawn_egg",
+      "damage": 11
     },
     {
-      "id" : "minecraft:pig_spawn_egg"
+      "id" : "minecraft:pig_spawn_egg",
+      "damage": 12
     },
     {
-      "id" : "minecraft:sheep_spawn_egg"
+      "id" : "minecraft:sheep_spawn_egg",
+      "damage": 13
     },
     {
-      "id" : "minecraft:wolf_spawn_egg"
+      "id" : "minecraft:wolf_spawn_egg",
+      "damage": 14
     },
     {
-      "id" : "minecraft:polar_bear_spawn_egg"
+      "id" : "minecraft:polar_bear_spawn_egg",
+      "damage": 28
     },
     {
-      "id" : "minecraft:ocelot_spawn_egg"
+      "id" : "minecraft:ocelot_spawn_egg",
+      "damage": 22
     },
     {
-      "id" : "minecraft:cat_spawn_egg"
+      "id" : "minecraft:cat_spawn_egg",
+      "damage": 75
     },
     {
-      "id" : "minecraft:mooshroom_spawn_egg"
+      "id" : "minecraft:mooshroom_spawn_egg",
+      "damage": 16
     },
     {
-      "id" : "minecraft:bat_spawn_egg"
+      "id" : "minecraft:bat_spawn_egg",
+      "damage": 19
     },
     {
-      "id" : "minecraft:parrot_spawn_egg"
+      "id" : "minecraft:parrot_spawn_egg",
+      "damage": 30
     },
     {
-      "id" : "minecraft:rabbit_spawn_egg"
+      "id" : "minecraft:rabbit_spawn_egg",
+      "damage": 18
     },
     {
-      "id" : "minecraft:llama_spawn_egg"
+      "id" : "minecraft:llama_spawn_egg",
+      "damage": 29
     },
     {
-      "id" : "minecraft:horse_spawn_egg"
+      "id" : "minecraft:horse_spawn_egg",
+      "damage": 23
     },
     {
-      "id" : "minecraft:donkey_spawn_egg"
+      "id" : "minecraft:donkey_spawn_egg",
+      "damage": 24
     },
     {
-      "id" : "minecraft:mule_spawn_egg"
+      "id" : "minecraft:mule_spawn_egg",
+      "damage": 25
     },
     {
-      "id" : "minecraft:skeleton_horse_spawn_egg"
+      "id" : "minecraft:skeleton_horse_spawn_egg",
+      "damage": 26
     },
     {
-      "id" : "minecraft:zombie_horse_spawn_egg"
+      "id" : "minecraft:zombie_horse_spawn_egg",
+      "damage": 27
     },
     {
-      "id" : "minecraft:tropical_fish_spawn_egg"
+      "id" : "minecraft:tropical_fish_spawn_egg",
+      "damage": 111
     },
     {
-      "id" : "minecraft:cod_spawn_egg"
+      "id" : "minecraft:cod_spawn_egg",
+      "damage": 112
     },
     {
-      "id" : "minecraft:pufferfish_spawn_egg"
+      "id" : "minecraft:pufferfish_spawn_egg",
+      "damage": 108
     },
     {
-      "id" : "minecraft:salmon_spawn_egg"
+      "id" : "minecraft:salmon_spawn_egg",
+      "damage": 109
     },
     {
-      "id" : "minecraft:dolphin_spawn_egg"
+      "id" : "minecraft:dolphin_spawn_egg",
+      "damage": 31
     },
     {
-      "id" : "minecraft:turtle_spawn_egg"
+      "id" : "minecraft:turtle_spawn_egg",
+      "damage": 74
     },
     {
-      "id" : "minecraft:panda_spawn_egg"
+      "id" : "minecraft:panda_spawn_egg",
+      "damage": 113
     },
     {
-      "id" : "minecraft:fox_spawn_egg"
+      "id" : "minecraft:fox_spawn_egg",
+      "damage": 121
     },
     {
-      "id" : "minecraft:creeper_spawn_egg"
+      "id" : "minecraft:creeper_spawn_egg",
+      "damage": 33
     },
     {
-      "id" : "minecraft:enderman_spawn_egg"
+      "id" : "minecraft:enderman_spawn_egg",
+      "damage": 38
     },
     {
-      "id" : "minecraft:silverfish_spawn_egg"
+      "id" : "minecraft:silverfish_spawn_egg",
+      "damage": 39
     },
     {
-      "id" : "minecraft:skeleton_spawn_egg"
+      "id" : "minecraft:skeleton_spawn_egg",
+      "damage": 34
     },
     {
-      "id" : "minecraft:wither_skeleton_spawn_egg"
+      "id" : "minecraft:wither_skeleton_spawn_egg",
+      "damage": 48
     },
     {
-      "id" : "minecraft:stray_spawn_egg"
+      "id" : "minecraft:stray_spawn_egg",
+      "damage": 46
     },
     {
-      "id" : "minecraft:slime_spawn_egg"
+      "id" : "minecraft:slime_spawn_egg",
+      "damage": 47
     },
     {
-      "id" : "minecraft:spider_spawn_egg"
+      "id" : "minecraft:spider_spawn_egg",
+      "damage": 35
     },
     {
-      "id" : "minecraft:zombie_spawn_egg"
+      "id" : "minecraft:zombie_spawn_egg",
+      "damage": 32
     },
     {
-      "id" : "minecraft:zombie_pigman_spawn_egg"
+      "id" : "minecraft:zombie_pigman_spawn_egg",
+      "damage": 36
     },
     {
-      "id" : "minecraft:husk_spawn_egg"
+      "id" : "minecraft:husk_spawn_egg",
+      "damage": 47
     },
     {
-      "id" : "minecraft:drowned_spawn_egg"
+      "id" : "minecraft:drowned_spawn_egg",
+      "damage": 110
     },
     {
-      "id" : "minecraft:squid_spawn_egg"
+      "id" : "minecraft:squid_spawn_egg",
+      "damage": 17
     },
     {
-      "id" : "minecraft:cave_spider_spawn_egg"
+      "id" : "minecraft:cave_spider_spawn_egg",
+      "damage": 40
     },
     {
-      "id" : "minecraft:witch_spawn_egg"
+      "id" : "minecraft:witch_spawn_egg",
+      "damage": 45
     },
     {
-      "id" : "minecraft:guardian_spawn_egg"
+      "id" : "minecraft:guardian_spawn_egg",
+      "damage": 49
     },
     {
-      "id" : "minecraft:elder_guardian_spawn_egg"
+      "id" : "minecraft:elder_guardian_spawn_egg",
+      "damage": 50
     },
     {
-      "id" : "minecraft:endermite_spawn_egg"
+      "id" : "minecraft:endermite_spawn_egg",
+      "damage": 55
     },
     {
-      "id" : "minecraft:magma_cube_spawn_egg"
+      "id" : "minecraft:magma_cube_spawn_egg",
+      "damage": 42
     },
     {
-      "id" : "minecraft:strider_spawn_egg"
+      "id" : "minecraft:strider_spawn_egg",
+      "damage": 125
     },
     {
-      "id" : "minecraft:hoglin_spawn_egg"
+      "id" : "minecraft:hoglin_spawn_egg",
+      "damage": 124
     },
     {
-      "id" : "minecraft:piglin_spawn_egg"
+      "id" : "minecraft:piglin_spawn_egg",
+      "damage": 123
     },
     {
-      "id" : "minecraft:zoglin_spawn_egg"
+      "id" : "minecraft:zoglin_spawn_egg",
+      "damage": 126
     },
     {
-      "id" : "minecraft:piglin_brute_spawn_egg"
+      "id" : "minecraft:piglin_brute_spawn_egg",
+      "damage": 127
     },
     {
-      "id" : "minecraft:ghast_spawn_egg"
+      "id" : "minecraft:ghast_spawn_egg",
+      "damage": 41
     },
     {
-      "id" : "minecraft:blaze_spawn_egg"
+      "id" : "minecraft:blaze_spawn_egg",
+      "damage": 43
     },
     {
-      "id" : "minecraft:shulker_spawn_egg"
+      "id" : "minecraft:shulker_spawn_egg",
+      "damage": 54
     },
     {
-      "id" : "minecraft:vindicator_spawn_egg"
+      "id" : "minecraft:vindicator_spawn_egg",
+      "damage": 57
     },
     {
-      "id" : "minecraft:evoker_spawn_egg"
+      "id" : "minecraft:evoker_spawn_egg",
+      "damage": 104
     },
     {
-      "id" : "minecraft:vex_spawn_egg"
+      "id" : "minecraft:vex_spawn_egg",
+      "damage": 105
     },
     {
-      "id" : "minecraft:villager_spawn_egg"
+      "id" : "minecraft:villager_spawn_egg",
+      "damage": 15
     },
     {
-      "id" : "minecraft:wandering_trader_spawn_egg"
+      "id" : "minecraft:wandering_trader_spawn_egg",
+      "damage": 118
     },
     {
-      "id" : "minecraft:zombie_villager_spawn_egg"
+      "id" : "minecraft:zombie_villager_spawn_egg",
+      "damage": 44
     },
     {
-      "id" : "minecraft:phantom_spawn_egg"
+      "id" : "minecraft:phantom_spawn_egg",
+      "damage": 58
     },
     {
-      "id" : "minecraft:pillager_spawn_egg"
+      "id" : "minecraft:pillager_spawn_egg",
+      "damage": 114
     },
     {
-      "id" : "minecraft:ravager_spawn_egg"
+      "id" : "minecraft:ravager_spawn_egg",
+      "damage": 59
     },
     {
       "id" : "minecraft:obsidian"
@@ -3397,25 +3478,32 @@
       "id" : "minecraft:bucket"
     },
     {
-      "id" : "minecraft:milk_bucket"
+      "id" : "minecraft:milk_bucket",
+      "damage": 1
     },
     {
-      "id" : "minecraft:water_bucket"
+      "id" : "minecraft:water_bucket",
+      "damage": 8
     },
     {
-      "id" : "minecraft:lava_bucket"
+      "id" : "minecraft:lava_bucket",
+      "damage": 10
     },
     {
-      "id" : "minecraft:cod_bucket"
+      "id" : "minecraft:cod_bucket",
+      "damage": 2
     },
     {
-      "id" : "minecraft:salmon_bucket"
+      "id" : "minecraft:salmon_bucket",
+      "damage": 3
     },
     {
-      "id" : "minecraft:tropical_fish_bucket"
+      "id" : "minecraft:tropical_fish_bucket",
+      "damage": 4
     },
     {
-      "id" : "minecraft:pufferfish_bucket"
+      "id" : "minecraft:pufferfish_bucket",
+      "damage": 5
     },
     {
       "id" : "minecraft:skull",
@@ -4019,19 +4107,24 @@
       "id" : "minecraft:oak_boat"
     },
     {
-      "id" : "minecraft:spruce_boat"
+      "id" : "minecraft:spruce_boat",
+      "damage": 1
     },
     {
-      "id" : "minecraft:birch_boat"
+      "id" : "minecraft:birch_boat",
+      "damage": 2
     },
     {
-      "id" : "minecraft:jungle_boat"
+      "id" : "minecraft:jungle_boat",
+      "damage": 3
     },
     {
-      "id" : "minecraft:acacia_boat"
+      "id" : "minecraft:acacia_boat",
+      "damage": 4
     },
     {
-      "id" : "minecraft:dark_oak_boat"
+      "id" : "minecraft:dark_oak_boat",
+      "damage": 5
     },
     {
       "id" : "minecraft:rail"


### PR DESCRIPTION
Prepare the system to use blockRuntimeId instead of damage (need to update runtime_block_states.dat), damage is still compatible