### PR TITLE
Fixes backward compatibility with generators.

### DIFF
--- a/src/main/java/cn/nukkit/level/format/anvil/util/BlockStorage.java
+++ b/src/main/java/cn/nukkit/level/format/anvil/util/BlockStorage.java
@@ -79,9 +79,20 @@ public class BlockStorage {
     }
 
     private static int getIndex(int x, int y, int z) {
+        checkArg(x, "x");
+        checkArg(x, "y");
+        checkArg(x, "z");
         int index = (x << 8) + (z << 4) + y; // XZY = Bedrock format
         Preconditions.checkArgument(index >= 0 && index < SECTION_SIZE, "Invalid index");
         return index;
+    }
+
+    private static void checkArg(int pos, String arg) {
+        try {
+            Preconditions.checkElementIndex(pos, 16, arg);
+        } catch (IndexOutOfBoundsException e) {
+            throw new IllegalArgumentException(e);
+        }
     }
 
     @Deprecated

--- a/src/main/java/cn/nukkit/level/format/generic/BaseChunk.java
+++ b/src/main/java/cn/nukkit/level/format/generic/BaseChunk.java
@@ -395,12 +395,12 @@ public abstract class BaseChunk extends BaseFullChunk implements Chunk {
     @Since("1.4.0.0-PN")
     @Override
     public boolean setBlockStateAt(int x, int y, int z, int layer, BlockState state) {
-        return setBlockStateAtLayer(x, y, z, layer, state);
+        return setBlockStateAtLayer(x & 0xF, y, z & 0XF, layer, state);
     }
 
     @Override
     public BlockState getBlockStateAt(int x, int y, int z, int layer) {
-        return getBlockState(x, y, z, layer);
+        return getBlockState(x & 0xF, y, z & 0xF, layer);
     }
 
     @Override

--- a/src/test/java/cn/nukkit/level/format/generic/BaseChunkTest.java
+++ b/src/test/java/cn/nukkit/level/format/generic/BaseChunkTest.java
@@ -36,7 +36,43 @@ class BaseChunkTest {
         chunk.setProvider(anvil);
         chunk.providerClass = Anvil.class;
     }
-    
+
+    /**
+     * Cloudburst Nukkit don't validate xyz, instead, it uses only the 4 least significant bits. We must do the same.
+     */
+    @Test
+    void github1138() {
+        chunk.setBlockAt(0x10, 0, 0, BlockID.BEDROCK);
+        assertEquals(BlockID.BEDROCK, chunk.getBlockId(0, 0, 0));
+        chunk.setBlockAt(0, 0, 0, BlockID.AIR);
+        assertEquals(BlockID.AIR, chunk.getBlockId(0, 0, 0));
+
+        chunk.setBlockAt(0, 0x10, 0, BlockID.BEDROCK);
+        assertEquals(BlockID.BEDROCK, chunk.getBlockId(0, 0x10, 0));
+        chunk.setBlockAt(0, 0x10, 0, BlockID.AIR);
+        assertEquals(BlockID.AIR, chunk.getBlockId(0, 0x10, 0));
+
+        chunk.setBlockAt(0, 0, 0x10, BlockID.BEDROCK);
+        assertEquals(BlockID.BEDROCK, chunk.getBlockId(0, 0, 0));
+        chunk.setBlockAt(0, 0, 0, BlockID.AIR);
+        assertEquals(BlockID.AIR, chunk.getBlockId(0, 0, 0));
+
+        chunk.setBlockAt(0x13, 0, 0, BlockID.BEDROCK);
+        assertEquals(BlockID.BEDROCK, chunk.getBlockId(3, 0, 0));
+        chunk.setBlockAt(3, 0, 0, BlockID.AIR);
+        assertEquals(BlockID.AIR, chunk.getBlockId(3, 0, 0));
+
+        chunk.setBlockAt(0, 0x13, 0, BlockID.BEDROCK);
+        assertEquals(BlockID.BEDROCK, chunk.getBlockId(0, 0x13, 0));
+        chunk.setBlockAt(0, 0x13, 0, BlockID.AIR);
+        assertEquals(BlockID.AIR, chunk.getBlockId(0, 0x13, 0));
+
+        chunk.setBlockAt(0, 0, 0x13, BlockID.BEDROCK);
+        assertEquals(BlockID.BEDROCK, chunk.getBlockId(0, 0, 3));
+        chunk.setBlockAt(0, 0, 3, BlockID.AIR);
+        assertEquals(BlockID.AIR, chunk.getBlockId(0, 0, 3));
+    }
+
     @Test
     void isBlockChangeAllowed() {
         BlockState allow = BlockState.of(BlockID.ALLOW);


### PR DESCRIPTION
Some generators were setting blocks outside the chunk range, Nukkit truncate the bits in that situation, PowerNukkit were throwing exceptions.

Fix #1138 