### PR TITLE
Wrong calculation of additional damage for sharpness enchantments

### DIFF
--- a/src/main/java/cn/nukkit/item/enchantment/damage/EnchantmentDamageAll.java
+++ b/src/main/java/cn/nukkit/item/enchantment/damage/EnchantmentDamageAll.java
@@ -32,6 +32,6 @@ public class EnchantmentDamageAll extends EnchantmentDamage {
             return 0;
         }
 
-        return 0.5 + getLevel() * 0.5;
+        return getLevel() * 1.25;
     }
 }


### PR DESCRIPTION
This pull request changes the formula to the correct one.
For the calculation formula, I referred to the following site.
https://minecraft.fandom.com/wiki/Sharpness#Usage