### PR TITLE
Fix and improve resource pack related packets

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2476,7 +2476,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                                 ResourcePackDataInfoPacket dataInfoPacket = new ResourcePackDataInfoPacket();
                                 dataInfoPacket.packId = resourcePack.getPackId();
                                 dataInfoPacket.maxChunkSize = ResourcePackManager.getMaxChunkSize(); // 102400 is default
-                                dataInfoPacket.chunkCount = resourcePack.getPackSize() / dataInfoPacket.maxChunkSize;
+                                dataInfoPacket.chunkCount = Math.ceil(resourcePack.getPackSize() / (double) dataInfoPacket.maxChunkSize);
                                 dataInfoPacket.compressedPackSize = resourcePack.getPackSize();
                                 dataInfoPacket.sha256 = resourcePack.getSha256();
                                 this.dataPacket(dataInfoPacket);

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -68,6 +68,7 @@ import cn.nukkit.positiontracking.PositionTracking;
 import cn.nukkit.positiontracking.PositionTrackingService;
 import cn.nukkit.potion.Effect;
 import cn.nukkit.resourcepacks.ResourcePack;
+import cn.nukkit.resourcepacks.ResourcePackManager;
 import cn.nukkit.scheduler.AsyncTask;
 import cn.nukkit.scheduler.TaskHandler;
 import cn.nukkit.utils.*;
@@ -2476,7 +2477,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                                 ResourcePackDataInfoPacket dataInfoPacket = new ResourcePackDataInfoPacket();
                                 dataInfoPacket.packId = resourcePack.getPackId();
                                 dataInfoPacket.maxChunkSize = ResourcePackManager.getMaxChunkSize(); // 102400 is default
-                                dataInfoPacket.chunkCount = Math.ceil(resourcePack.getPackSize() / (double) dataInfoPacket.maxChunkSize);
+                                dataInfoPacket.chunkCount = (int) Math.ceil(resourcePack.getPackSize() / (double) dataInfoPacket.maxChunkSize);
                                 dataInfoPacket.compressedPackSize = resourcePack.getPackSize();
                                 dataInfoPacket.sha256 = resourcePack.getSha256();
                                 this.dataPacket(dataInfoPacket);

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2475,7 +2475,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                                 }
 
                                 ResourcePackDataInfoPacket dataInfoPacket = new ResourcePackDataInfoPacket();
-                                dataInfoPacket.packId = resourcePack.getPackId();
+                                dataInfoPacket.packInfo = resourcePack.getPackId().toString() + "_" + resourcePack.getPackVersion();
                                 dataInfoPacket.maxChunkSize = ResourcePackManager.getMaxChunkSize(); // 102400 is default
                                 dataInfoPacket.chunkCount = (int) Math.ceil(resourcePack.getPackSize() / (double) dataInfoPacket.maxChunkSize);
                                 dataInfoPacket.compressedPackSize = resourcePack.getPackSize();
@@ -2500,14 +2500,14 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     break;
                 case ProtocolInfo.RESOURCE_PACK_CHUNK_REQUEST_PACKET:
                     ResourcePackChunkRequestPacket requestPacket = (ResourcePackChunkRequestPacket) packet;
-                    ResourcePack resourcePack = this.server.getResourcePackManager().getPackById(requestPacket.packId);
+                    ResourcePack resourcePack = this.server.getResourcePackManager().getPackById(UUID.fromString(requestPacket.packInfo.split("_")[0])); // TODO: Pack version check
                     if (resourcePack == null) {
                         this.close("", "disconnectionScreen.resourcePack");
                         break;
                     }
 
                     ResourcePackChunkDataPacket dataPacket = new ResourcePackChunkDataPacket();
-                    dataPacket.packId = resourcePack.getPackId();
+                    dataPacket.packInfo = resourcePack.getPackId().toString() + "_" + resourcePack.getPackVersion();
                     dataPacket.chunkIndex = requestPacket.chunkIndex;
                     dataPacket.data = resourcePack.getPackChunk(ResourcePackManager.getMaxChunkSize() * requestPacket.chunkIndex, ResourcePackManager.getMaxChunkSize());
                     dataPacket.progress = ResourcePackManager.getMaxChunkSize() * requestPacket.chunkIndex;

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2475,7 +2475,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
                                 ResourcePackDataInfoPacket dataInfoPacket = new ResourcePackDataInfoPacket();
                                 dataInfoPacket.packId = resourcePack.getPackId();
-                                dataInfoPacket.maxChunkSize = 1048576; //megabyte
+                                dataInfoPacket.maxChunkSize = ResourcePackManager.getMaxChunkSize(); // 102400 is default
                                 dataInfoPacket.chunkCount = resourcePack.getPackSize() / dataInfoPacket.maxChunkSize;
                                 dataInfoPacket.compressedPackSize = resourcePack.getPackSize();
                                 dataInfoPacket.sha256 = resourcePack.getSha256();
@@ -2508,8 +2508,8 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     ResourcePackChunkDataPacket dataPacket = new ResourcePackChunkDataPacket();
                     dataPacket.packId = resourcePack.getPackId();
                     dataPacket.chunkIndex = requestPacket.chunkIndex;
-                    dataPacket.data = resourcePack.getPackChunk(1048576 * requestPacket.chunkIndex, 1048576);
-                    dataPacket.progress = 1048576 * requestPacket.chunkIndex;
+                    dataPacket.data = resourcePack.getPackChunk(ResourcePackManager.getMaxChunkSize() * requestPacket.chunkIndex, ResourcePackManager.getMaxChunkSize());
+                    dataPacket.progress = ResourcePackManager.getMaxChunkSize() * requestPacket.chunkIndex;
                     this.dataPacket(dataPacket);
                     break;
                 case ProtocolInfo.SET_LOCAL_PLAYER_AS_INITIALIZED_PACKET:

--- a/src/main/java/cn/nukkit/network/protocol/ResourcePackChunkDataPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/ResourcePackChunkDataPacket.java
@@ -1,5 +1,8 @@
 package cn.nukkit.network.protocol;
 
+import cn.nukkit.api.PowerNukkitOnly;
+import cn.nukkit.api.Since;
+
 import lombok.ToString;
 
 import java.util.UUID;
@@ -9,14 +12,23 @@ public class ResourcePackChunkDataPacket extends DataPacket {
 
     public static final byte NETWORK_ID = ProtocolInfo.RESOURCE_PACK_CHUNK_DATA_PACKET;
 
+    @Deprecated
     public UUID packId;
+    @PowerNukkitOnly
+    @Since("FUTURE")
+    public String packInfo;
     public int chunkIndex;
     public long progress;
     public byte[] data;
 
     @Override
     public void decode() {
-        this.packId = UUID.fromString(this.getString());
+        String packInfo = this.getString();
+        try {
+            this.packId = UUID.fromString(packInfo);
+        } catch (IllegalArgumentException exception) {
+            this.packInfo = packInfo;
+        }
         this.chunkIndex = this.getLInt();
         this.progress = this.getLLong();
         this.data = this.getByteArray();
@@ -25,7 +37,12 @@ public class ResourcePackChunkDataPacket extends DataPacket {
     @Override
     public void encode() {
         this.reset();
-        this.putString(this.packId.toString());
+        
+        if (packInfo == null) {
+            this.putString(this.packId.toString());
+        } else {
+            this.putString(this.packInfo);
+        }
         this.putLInt(this.chunkIndex);
         this.putLLong(this.progress);
         this.putByteArray(this.data);

--- a/src/main/java/cn/nukkit/network/protocol/ResourcePackChunkRequestPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/ResourcePackChunkRequestPacket.java
@@ -1,5 +1,8 @@
 package cn.nukkit.network.protocol;
 
+import cn.nukkit.api.PowerNukkitOnly;
+import cn.nukkit.api.Since;
+
 import lombok.ToString;
 
 import java.util.UUID;
@@ -9,19 +12,32 @@ public class ResourcePackChunkRequestPacket extends DataPacket {
 
     public static final byte NETWORK_ID = ProtocolInfo.RESOURCE_PACK_CHUNK_REQUEST_PACKET;
 
+    @Deprecated
     public UUID packId;
+    @PowerNukkitOnly
+    @Since("FUTURE")
+    public String packInfo;
     public int chunkIndex;
 
     @Override
     public void decode() {
-        this.packId = UUID.fromString(this.getString());
+        String packInfo = this.getString();
+        try {
+            this.packId = UUID.fromString(packInfo);
+        } catch (IllegalArgumentException exception) {
+            this.packInfo = packInfo;
+        }
         this.chunkIndex = this.getLInt();
     }
 
     @Override
     public void encode() {
         this.reset();
-        this.putString(this.packId.toString());
+        if (packInfo == null) {
+            this.putString(this.packId.toString());
+        } else {
+            this.putString(this.packInfo);
+        }
         this.putLInt(this.chunkIndex);
     }
 

--- a/src/main/java/cn/nukkit/network/protocol/ResourcePackDataInfoPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/ResourcePackDataInfoPacket.java
@@ -20,7 +20,11 @@ public class ResourcePackDataInfoPacket extends DataPacket {
     public static final int TYPE_WORLD_TEMPLATE = 8;
     public static final int TYPE_COUNT = 9;
 
+    @Deprecated
     public UUID packId;
+    @PowerNukkitOnly
+    @Since("FUTURE")
+    public String packInfo;
     public int maxChunkSize;
     public int chunkCount;
     public long compressedPackSize;
@@ -30,7 +34,14 @@ public class ResourcePackDataInfoPacket extends DataPacket {
 
     @Override
     public void decode() {
-        this.packId = UUID.fromString(this.getString());
+        String packInfo = this.getString();
+        try {
+            packId = UUID.fromString(packInfo);
+        } catch (IllegalArgumentException exception) {
+            packId = null;
+        }
+        this.packId = UUID.fromString(packInfo);
+        this.packInfo = packInfo;
         this.maxChunkSize = this.getLInt();
         this.chunkCount = this.getLInt();
         this.compressedPackSize = this.getLLong();
@@ -42,7 +53,11 @@ public class ResourcePackDataInfoPacket extends DataPacket {
     @Override
     public void encode() {
         this.reset();
-        this.putString(this.packId.toString());
+        if (packInfo == null) {
+            this.putString(this.packId.toString());
+        } else {
+            this.putString(this.packInfo);
+        }
         this.putLInt(this.maxChunkSize);
         this.putLInt(this.chunkCount);
         this.putLLong(this.compressedPackSize);

--- a/src/main/java/cn/nukkit/network/protocol/ResourcePackDataInfoPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/ResourcePackDataInfoPacket.java
@@ -1,5 +1,8 @@
 package cn.nukkit.network.protocol;
 
+import cn.nukkit.api.PowerNukkitOnly;
+import cn.nukkit.api.Since;
+
 import lombok.ToString;
 
 import java.util.UUID;

--- a/src/main/java/cn/nukkit/network/protocol/ResourcePacksInfoPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/ResourcePacksInfoPacket.java
@@ -21,6 +21,7 @@ public class ResourcePacksInfoPacket extends DataPacket {
     @Override
     public void encode() {
         this.reset();
+        
         this.putBoolean(this.mustAccept);
         this.putBoolean(this.scripting);
 
@@ -36,7 +37,7 @@ public class ResourcePacksInfoPacket extends DataPacket {
             this.putLLong(entry.getPackSize());
             this.putString(""); // encryption key
             this.putString(""); // sub-pack name
-            this.putString(""); // content identity
+            this.putString(entry.getPackId().toString()); // content identity
             this.putBoolean(false); // scripting
             this.putBoolean(false); // raytracing capable
         }

--- a/src/main/java/cn/nukkit/resourcepacks/ResourcePackManager.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ResourcePackManager.java
@@ -14,7 +14,7 @@ import java.util.*;
 @Log4j2
 public class ResourcePackManager {
 
-    private static final int MAX_CHUNK_SIZE = 102400;
+    private static int MAX_CHUNK_SIZE = 102400;
     
     private final Map<UUID, ResourcePack> resourcePacksById = new HashMap<>();
     private ResourcePack[] resourcePacks;
@@ -69,7 +69,13 @@ public class ResourcePackManager {
     
     @PowerNukkitOnly
     @Since("FUTURE")
-    public static getMaxChunkSize() {
+    public static int getMaxChunkSize() {
         return MAX_CHUNK_SIZE;
+    }
+    
+    @PowerNukkitOnly
+    @Since("FUTURE")
+    public static void setMaxChunkSize(int maxChunkSize) {
+        MAX_CHUNK_SIZE = maxChunkSize;
     }
 }

--- a/src/main/java/cn/nukkit/resourcepacks/ResourcePackManager.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ResourcePackManager.java
@@ -1,7 +1,11 @@
 package cn.nukkit.resourcepacks;
 
 import cn.nukkit.Server;
+import cn.nukkit.api.PowerNukkitOnly;
+import cn.nukkit.api.Since;
+
 import com.google.common.io.Files;
+
 import lombok.extern.log4j.Log4j2;
 
 import java.io.File;
@@ -9,6 +13,9 @@ import java.util.*;
 
 @Log4j2
 public class ResourcePackManager {
+
+    private static final int MAX_CHUNK_SIZE = 102400;
+    
     private final Map<UUID, ResourcePack> resourcePacksById = new HashMap<>();
     private ResourcePack[] resourcePacks;
 
@@ -58,5 +65,11 @@ public class ResourcePackManager {
 
     public ResourcePack getPackById(UUID id) {
         return this.resourcePacksById.get(id);
+    }
+    
+    @PowerNukkitOnly
+    @Since("FUTURE")
+    public static getMaxChunkSize() {
+        return MAX_CHUNK_SIZE;
     }
 }


### PR DESCRIPTION
Fix and improve resource pack related packets

- Set max chunk size as BDS
- Make able to get and set max chunk size with plugin
- Fix chunk count calculation
- Update resource pack related packets (missing version)