### PR TITLE
Fixed the names for BlockConcrete and BlockConcretePowder

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockConcrete.java
+++ b/src/main/java/cn/nukkit/block/BlockConcrete.java
@@ -68,10 +68,10 @@ public class BlockConcrete extends BlockSolidMeta {
 
     @Override
     public BlockColor getColor() {
-        return DyeColor.getByWoolData(getDamage()).getColor();
+        return getDyeColor().getColor();
     }
 
     public DyeColor getDyeColor() {
-        return DyeColor.getByWoolData(getDamage());
+        return getPropertyValue(CommonBlockProperties.COLOR);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockConcrete.java
+++ b/src/main/java/cn/nukkit/block/BlockConcrete.java
@@ -53,7 +53,7 @@ public class BlockConcrete extends BlockSolidMeta {
 
     @Override
     public String getName() {
-        return "Concrete";
+        return getDyeColor().getName() + " Concrete";
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockConcretePowder.java
+++ b/src/main/java/cn/nukkit/block/BlockConcretePowder.java
@@ -10,6 +10,7 @@ import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemTool;
 import cn.nukkit.level.Level;
 import cn.nukkit.math.BlockFace;
+import cn.nukkit.utils.BlockColor;
 import cn.nukkit.utils.DyeColor;
 
 import javax.annotation.Nonnull;
@@ -103,7 +104,12 @@ public class BlockConcretePowder extends BlockFallableMeta {
         return true;
     }
 
+    @Override
+    public BlockColor getColor() {
+        return getDyeColor().getColor();
+    }
+
     public DyeColor getDyeColor() {
-        return DyeColor.getByWoolData(getDamage());
+        return getPropertyValue(CommonBlockProperties.COLOR);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockConcretePowder.java
+++ b/src/main/java/cn/nukkit/block/BlockConcretePowder.java
@@ -10,6 +10,7 @@ import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemTool;
 import cn.nukkit.level.Level;
 import cn.nukkit.math.BlockFace;
+import cn.nukkit.utils.DyeColor;
 
 import javax.annotation.Nonnull;
 
@@ -46,7 +47,7 @@ public class BlockConcretePowder extends BlockFallableMeta {
 
     @Override
     public String getName() {
-        return "Concrete Powder";
+        return getDyeColor().getName() + " Concrete Powder";
     }
 
     @Override
@@ -100,5 +101,9 @@ public class BlockConcretePowder extends BlockFallableMeta {
         }
 
         return true;
+    }
+
+    public DyeColor getDyeColor() {
+        return DyeColor.getByWoolData(getDamage());
     }
 }


### PR DESCRIPTION
The names for Concrete and Concrete Powder when getting a block, is just concrete, it doesn't specify the colored name of the blocks, this is just a simple fix for it!