### PR TITLE
Backward compatibility fix with AntiXRay PowerNukkit port.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Nukkit 1.X and 2.X.
 ## [Unreleased 1.6.0.1-PN] - Future ([Check the milestone](https://github.com/PowerNukkit/PowerNukkit/milestone/27?closed=1))
 Click the link above to see the future.
 
+### Fixes
+- [#1344] Backward compatibility with PowerNukkit port of Wode's AntiXRay plugin
+
+### Changed
+- [#1344] Log4J version to `2.17.1` (seriously, stop hacking it people)
+
 ## [1.6.0.0-PN] - 2022-04-20 ([Check the milestone](https://github.com/PowerNukkit/PowerNukkit/milestone/29?closed=1))
 Major version change adding support to Minecraft `1.18.30`.
 
@@ -1012,3 +1018,4 @@ Fixes several anvil issues.
 [#1267]: https://github.com/PowerNukkit/PowerNukkit/issues/1267
 [#1270]: https://github.com/PowerNukkit/PowerNukkit/issues/1270
 [#1341]: https://github.com/PowerNukkit/PowerNukkit/issues/1341
+[#1344]: https://github.com/PowerNukkit/PowerNukkit/issues/1344

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <junit.jupiter.version>5.7.2</junit.jupiter.version>
         <mockito.version>3.11.2</mockito.version>
-        <log4j2.version>2.17.0</log4j2.version>
+        <log4j2.version>2.17.1</log4j2.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jline.version>3.9.0</jline.version>

--- a/src/main/java/cn/nukkit/level/util/PalettedBlockStorage.java
+++ b/src/main/java/cn/nukkit/level/util/PalettedBlockStorage.java
@@ -1,7 +1,10 @@
 package cn.nukkit.level.util;
 
+import cn.nukkit.api.DeprecationDetails;
+import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
-import cn.nukkit.level.GlobalBlockPalette;
+import cn.nukkit.block.BlockID;
+import cn.nukkit.blockstate.BlockStateRegistry;
 import cn.nukkit.utils.BinaryStream;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -22,8 +25,8 @@ public class PalettedBlockStorage {
 
     @Since("1.6.0.0-PN")
     public static PalettedBlockStorage createFromBlockPalette(BitArrayVersion version) {
-        int runtimeId = GlobalBlockPalette.getOrCreateRuntimeId(0); // Air is first
-        return new PalettedBlockStorage(version, runtimeId);
+        int runtimeId = BlockStateRegistry.getRuntimeId(BlockID.AIR);
+        return new PalettedBlockStorage(version, runtimeId, null);
     }
 
     @Since("1.6.0.0-PN")
@@ -33,10 +36,32 @@ public class PalettedBlockStorage {
 
     @Since("1.6.0.0-PN")
     public static PalettedBlockStorage createWithDefaultState(BitArrayVersion version, int defaultState) {
-        return new PalettedBlockStorage(version, defaultState);
+        return new PalettedBlockStorage(version, defaultState, null);
     }
 
-    private PalettedBlockStorage(BitArrayVersion version, int defaultState) {
+    @PowerNukkitOnly("This was removed on 1.6.0.0-PN by Cloudburst Nukkit and re-added to fix plugin compatibility issue on 1.6.0.1-PN")
+    @Deprecated
+    @DeprecationDetails(
+            since = "1.6.0.0-PN",
+            reason = "Refactored by Cloudburst Nukkit to use static method instead of constructor",
+            replaceWith = "createFromBlockPalette()"
+    )
+    public PalettedBlockStorage() {
+        this(BitArrayVersion.V2, BlockStateRegistry.getRuntimeId(BlockID.AIR), null);
+    }
+
+    @PowerNukkitOnly("This was removed on 1.6.0.0-PN by Cloudburst Nukkit and re-added to fix plugin compatibility issue on 1.6.0.1-PN")
+    @Deprecated
+    @DeprecationDetails(
+            since = "1.6.0.0-PN",
+            reason = "Refactored by Cloudburst Nukkit to use static method instead of constructor",
+            replaceWith = "createFromBlockPalette(BitArrayVersion)"
+    )
+    public PalettedBlockStorage(BitArrayVersion version, int defaultState) {
+        this(version, defaultState, null);
+    }
+
+    private PalettedBlockStorage(BitArrayVersion version, int defaultState, @SuppressWarnings("unused") Void differentiator) {
         this.bitArray = version.createPalette(SIZE);
         this.palette = new IntArrayList(16);
         this.palette.add(defaultState);


### PR DESCRIPTION
Fixes:
```java
2022-04-20 18:01:22.032 [main] INFO  - Enabling AntiXray v1.2.3-PN.1
2022-04-20 18:01:22.041 [main] FATAL - An error occurred while enabling the plugin AntiXray, 1.2.3-PN.1, cn.wode490390.nukkit.antixray.AntiXray
java.lang.NoSuchMethodError: cn.nukkit.level.util.PalettedBlockStorage.<init>(Lcn/nukkit/level/util/BitArrayVersion;)V
	at cn.wode490390.nukkit.antixray.WorldHandler.<clinit>(WorldHandler.java:69) ~[?:?]
	at cn.wode490390.nukkit.antixray.AntiXray.onEnable(AntiXray.java:162) ~[?:?]
	at cn.nukkit.plugin.PluginBase.setEnabled(PluginBase.java:105) ~[custom.jar:?]
	at cn.nukkit.plugin.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:120) ~[custom.jar:?]
	at cn.nukkit.plugin.PluginManager.enablePlugin(PluginManager.java:461) [custom.jar:?]
	at cn.nukkit.Server.enablePlugin(Server.java:943) [custom.jar:?]
	at cn.nukkit.Server.enablePlugins(Server.java:932) [custom.jar:?]
	at cn.nukkit.Server.<init>(Server.java:770) [custom.jar:?]
	at cn.nukkit.Nukkit.main(Nukkit.java:200) [custom.jar:?]
```